### PR TITLE
Add type for schema

### DIFF
--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -121,6 +121,14 @@ interface updateCustomParameters {
   DELETE?: string[]
 }
 
+export interface Schema {
+  keys: {
+    partitionKey: string
+    sortKey?: string
+  }
+  attributes: EntityAttributes
+}
+
 type updateCustomParams = updateCustomParameters 
   & Partial<DocumentClient.UpdateItemInput>
 

--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -121,7 +121,7 @@ interface updateCustomParameters {
   DELETE?: string[]
 }
 
-export interface Schema {
+export interface schema {
   keys: {
     partitionKey: string
     sortKey?: string
@@ -141,7 +141,7 @@ class Entity<
   private _execute?: boolean
   private _parse?: boolean
   public name!: string
-  public schema: any
+  public schema: schema
   public _etAlias!: string
   public defaults: any
   public linked: any


### PR DESCRIPTION
I know this isn't 100% right because it is causing a few dozen typescript errors, but I think it is important to assign & export a type to `Entity.schema`.

I'm using eslint rules that prohibit unsafe any usage and it seems that the schema property is generally well-defined.

