### PR TITLE
docs(README): add correct deps to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Using your favorite package manager, install DynamoDB Toolbox and the aws-sdk v3
 ```bash
 # npm
 npm i dynamodb-toolbox
-npm install @aws-sdk/lib-dynamodb @aws-sdk/util-dynamodb
+npm install @aws-sdk/lib-dynamodb @aws-sdk/client-dynamodb
 
 # yarn
 yarn add dynamodb-toolbox
-yarn add @aws-sdk/lib-dynamodb @aws-sdk/util-dynamodb
+yarn add @aws-sdk/lib-dynamodb @aws-sdk/client-dynamodb
 ```
 
 Require or import `Table` and `Entity` from `dynamodb-toolbox`:
@@ -72,7 +72,7 @@ const unmarshallOptions = {
 const translateConfig = { marshallOptions, unmarshallOptions }
 
 // Instantiate a DocumentClient
-export const DocumentClient = DynamoDBDocumentClient.from(new DynamoDBClient(), translateConfig)
+export const DocumentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), translateConfig)
 
 
 // Instantiate a table


### PR DESCRIPTION
Sorry for the mistake.  😅 

The `@aws-sdk/client-dynamodb` needs to be imported of course, which also includes the `@aws-sdk/util-dynamodb`.

However, I personally would add `@aws-sdk/util-dynamodb` as a devDependency (see [import/no-extraneous-dependencies](https://github.com/import-js/eslint-plugin-import/blob/v2.27.5/docs/rules/no-extraneous-dependencies.md)) to the project.

----

Another small detail I've noticed, the constructor `DynamoDBClient` needs at least an empty object as argument.

