### PR TITLE
Use incrementing ids for expression keys

### DIFF
--- a/src/__tests__/entity.update.unit.test.ts
+++ b/src/__tests__/entity.update.unit.test.ts
@@ -128,7 +128,7 @@ const TestEntityGSI = new Entity({
 } as const)
 
 describe('update', () => {
-  it.only('creates default update', () => {
+  it('creates default update', () => {
     const {
       TableName,
       Key,

--- a/src/__tests__/entity.update.unit.test.ts
+++ b/src/__tests__/entity.update.unit.test.ts
@@ -102,7 +102,12 @@ const TestEntity4 = new Entity({
   autoExecute: false,
   attributes: {
     email: { type: 'string', partitionKey: true },
-    test_number_default_with_map: { type: 'number', map: 'test_mapped_number', default: 0, onUpdate: false },
+    test_number_default_with_map: {
+      type: 'number',
+      map: 'test_mapped_number',
+      default: 0,
+      onUpdate: false
+    }
   },
   timestamps: false,
   table: TestTable4
@@ -123,7 +128,7 @@ const TestEntityGSI = new Entity({
 } as const)
 
 describe('update', () => {
-  it('creates default update', () => {
+  it.only('creates default update', () => {
     const {
       TableName,
       Key,
@@ -133,25 +138,25 @@ describe('update', () => {
     } = TestEntity.updateParams({ email: 'test-pk', sort: 'test-sk' })
 
     expect(UpdateExpression).toBe(
-      'SET #test_string = if_not_exists(#test_string,:test_string), #test_number_coerce = if_not_exists(#test_number_coerce,:test_number_coerce), #test_boolean_default = if_not_exists(#test_boolean_default,:test_boolean_default), #_ct = if_not_exists(#_ct,:_ct), #_md = :_md, #_et = if_not_exists(#_et,:_et)'
+      'SET #attr1 = if_not_exists(#attr1,:attr1), #attr2 = if_not_exists(#attr2,:attr2), #attr3 = if_not_exists(#attr3,:attr3), #attr4 = if_not_exists(#attr4,:attr4), #attr5 = :attr5, #attr6 = if_not_exists(#attr6,:attr6)'
     )
     expect(ExpressionAttributeNames).toEqual({
-      '#_md': '_md',
-      '#_ct': '_ct',
-      '#test_string': 'test_string',
-      '#test_boolean_default': 'test_boolean_default',
-      '#test_number_coerce': 'test_number_coerce',
-      '#_et': '_et'
+      '#attr1': 'test_string',
+      '#attr2': 'test_number_coerce',
+      '#attr3': 'test_boolean_default',
+      '#attr4': '_ct',
+      '#attr5': '_md',
+      '#attr6': '_et'
     })
 
     assert.ok(ExpressionAttributeValues !== undefined, 'ExpressionAttributeValues is undefined')
-    expect(ExpressionAttributeValues).toHaveProperty(':_ct')
-    expect(ExpressionAttributeValues).toHaveProperty(':_md')
-    expect(ExpressionAttributeValues).toHaveProperty(':test_string')
-    expect(ExpressionAttributeValues).toHaveProperty(':test_number_coerce')
-    expect(ExpressionAttributeValues).toHaveProperty(':test_boolean_default')
-    expect(ExpressionAttributeValues).toHaveProperty(':_et')
-    expect(ExpressionAttributeValues?.[':_et']).toBe('TestEntity')
+    expect(ExpressionAttributeValues).toHaveProperty(':attr1')
+    expect(ExpressionAttributeValues).toHaveProperty(':attr2')
+    expect(ExpressionAttributeValues).toHaveProperty(':attr3')
+    expect(ExpressionAttributeValues).toHaveProperty(':attr4')
+    expect(ExpressionAttributeValues).toHaveProperty(':attr5')
+    expect(ExpressionAttributeValues).toHaveProperty(':attr6')
+    expect(ExpressionAttributeValues?.[':attr6']).toBe('TestEntity')
     expect(Key).toEqual({ pk: 'test-pk', sk: 'test-sk' })
     expect(TableName).toBe('test-table')
   })
@@ -235,12 +240,8 @@ describe('update', () => {
     expect(ExpressionAttributeNames?.['#test_mapped_number']).toBe('test_mapped_number')
     expect(ExpressionAttributeValues?.[':test_mapped_number']).toBe(111)
 
-    expect(UpdateExpression).toBe(
-      'SET #test_mapped_number = :test_mapped_number'
-    )
-
+    expect(UpdateExpression).toBe('SET #test_mapped_number = :test_mapped_number')
   })
-
 
   it('fails when removing fields with default values', () => {
     expect(() =>
@@ -390,18 +391,14 @@ describe('update', () => {
 
     expect(ExpressionAttributeValues?.[':test_string_set']).toEqual(new Set(['1', '2', '3']))
     expect(ExpressionAttributeValues?.[':test_number_set']).toEqual(new Set([1, 2, 3]))
-    expect(ExpressionAttributeValues?.[':test_binary_set']).toEqual(new Set([
-      Buffer.from('1'),
-      Buffer.from('2'),
-      Buffer.from('3')
-    ]))
+    expect(ExpressionAttributeValues?.[':test_binary_set']).toEqual(
+      new Set([Buffer.from('1'), Buffer.from('2'), Buffer.from('3')])
+    )
     expect(ExpressionAttributeValues?.[':test_string_set_type']).toEqual(new Set(['1', '2', '3']))
     expect(ExpressionAttributeValues?.[':test_number_set_type']).toEqual(new Set([1, 2, 3]))
-    expect(ExpressionAttributeValues?.[':test_binary_set_type']).toEqual(new Set([
-      Buffer.from('1'),
-      Buffer.from('2'),
-      Buffer.from('3')
-    ]))
+    expect(ExpressionAttributeValues?.[':test_binary_set_type']).toEqual(
+      new Set([Buffer.from('1'), Buffer.from('2'), Buffer.from('3')])
+    )
     expect(Key).toEqual({ pk: 'test-pk', sk: 'test-sk' })
     expect(TableName).toBe('test-table')
   })
@@ -500,7 +497,11 @@ describe('update', () => {
     expect(ExpressionAttributeValues).not.toHaveProperty(':sk')
     expect(ExpressionAttributeValues).toHaveProperty(':_et')
     expect(ExpressionAttributeValues?.[':_et']).toBe('TestEntity')
-    expect(Array.from(ExpressionAttributeValues?.[':test_string_set_type'])).toEqual(['1', '2', '3'])
+    expect(Array.from(ExpressionAttributeValues?.[':test_string_set_type'])).toEqual([
+      '1',
+      '2',
+      '3'
+    ])
     expect(Array.from(ExpressionAttributeValues?.[':test_number_set_type'])).toEqual([1, 2, 3])
     expect(Key).toEqual({ pk: 'test-pk', sk: 'test-sk' })
     expect(TableName).toBe('test-table')
@@ -638,7 +639,7 @@ describe('update', () => {
     )
   })
 
-  it('doesn\'t provide a default list value when not appending/prepending a value to a list', () => {
+  it("doesn't provide a default list value when not appending/prepending a value to a list", () => {
     const { TableName, Key, ExpressionAttributeValues } = TestEntity.updateParams({
       email: 'test-pk',
       sort: 'test-sk'
@@ -650,7 +651,7 @@ describe('update', () => {
     expect(ExpressionAttributeValues).not.toHaveProperty(ATTRIBUTE_VALUES_LIST_DEFAULT_KEY)
   })
 
-  it('doesn\'t provide a default list value when not appending/prepending a value to a nested list within a map.', () => {
+  it("doesn't provide a default list value when not appending/prepending a value to a nested list within a map.", () => {
     const {
       TableName,
       Key,
@@ -880,7 +881,7 @@ describe('update', () => {
     expect(ExpressionAttributeValues?.[':test3']).toBe(0)
   })
 
-  it('allows using list operations on a required list field', ()=> {
+  it('allows using list operations on a required list field', () => {
     const { ExpressionAttributeValues } = TestEntity.updateParams({
       email: 'test-pk',
       sort: 'test-sk',
@@ -927,7 +928,7 @@ describe('update', () => {
     ).toThrow(`Field 'unknown' does not have a mapping or alias`)
   })
 
-  it('fails when missing an \'always\' required field', () => {
+  it("fails when missing an 'always' required field", () => {
     // @ts-expect-error
     expect(() => TestEntity3.updateParams({ email: 'test-pk' })).toThrow(
       `'test2' is a required field`
@@ -1184,7 +1185,7 @@ describe('update', () => {
         { email: 'x', sort: 'y', unknown: '?' },
         { strictSchemaCheck: true }
       )
-    ).toThrow('Field \'unknown\' does not have a mapping or alias')
+    ).toThrow("Field 'unknown' does not have a mapping or alias")
   })
 
   it('allows unmapped attributes when strictSchemaCheck is false.', () => {
@@ -1211,11 +1212,11 @@ describe('update', () => {
   })
 
   it('should keep empty lists if removeNulls is true', () => {
-    const params = TestEntity.updateParams(
-      { email: 'x', sort: 'y', test_list: [] },
-    )
+    const params = TestEntity.updateParams({ email: 'x', sort: 'y', test_list: [] })
 
-    expect(params.UpdateExpression).toBe('SET #test_string = if_not_exists(#test_string,:test_string), #test_number_coerce = if_not_exists(#test_number_coerce,:test_number_coerce), #test_boolean_default = if_not_exists(#test_boolean_default,:test_boolean_default), #_ct = if_not_exists(#_ct,:_ct), #_md = :_md, #_et = if_not_exists(#_et,:_et), #test_list = :test_list')
+    expect(params.UpdateExpression).toBe(
+      'SET #test_string = if_not_exists(#test_string,:test_string), #test_number_coerce = if_not_exists(#test_number_coerce,:test_number_coerce), #test_boolean_default = if_not_exists(#test_boolean_default,:test_boolean_default), #_ct = if_not_exists(#_ct,:_ct), #_md = :_md, #_et = if_not_exists(#_et,:_et), #test_list = :test_list'
+    )
     expect(params.ExpressionAttributeNames).toEqual({
       '#_ct': '_ct',
       '#_et': '_et',
@@ -1223,14 +1224,14 @@ describe('update', () => {
       '#test_boolean_default': 'test_boolean_default',
       '#test_list': 'test_list',
       '#test_number_coerce': 'test_number_coerce',
-      '#test_string': 'test_string',
+      '#test_string': 'test_string'
     })
     expect(params.ExpressionAttributeValues).toEqual({
       ':_ct': expect.any(String),
       ':_et': 'TestEntity',
       ':_md': expect.any(String),
       ':test_boolean_default': false,
-      ':test_list':  [],
+      ':test_list': [],
       ':test_number_coerce': 0,
       ':test_string': 'default string'
     })

--- a/src/__tests__/expressionBuilder.unit.test.ts
+++ b/src/__tests__/expressionBuilder.unit.test.ts
@@ -4,6 +4,7 @@ import {
   default as expressionBuilder,
   SUPPORTED_FILTER_EXP_ATTR_REF_OPERATORS
 } from '../lib/expressionBuilder'
+import { ExpressionId } from '../lib/expressionId'
 
 const TestTable = new Table({
   name: 'test-table',
@@ -26,6 +27,12 @@ new Entity({
 } as const)
 
 describe('expressionBuilder', () => {
+  let expressionId = new ExpressionId()
+
+  beforeEach(() => {
+    expressionId = new ExpressionId()
+  })
+
   it('builds complex expression', () => {
     const nested_exp = [
       { attr: 'a', eq: 'b' },
@@ -56,7 +63,7 @@ describe('expressionBuilder', () => {
       ]
     ]
 
-    const result = expressionBuilder(nested_exp, TestTable, 'TestEntity')
+    const result = expressionBuilder(nested_exp, TestTable, expressionId, 'TestEntity')
 
     expect(result.names).toEqual({
       '#attr1': 'a',
@@ -100,234 +107,234 @@ describe('expressionBuilder', () => {
   })
 
   it('coerces expression input to array', () => {
-    const result = expressionBuilder({ attr: 'a', eq: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', eq: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it('fail with conditional operator errors', () => {
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', ne: 'b' }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', ne: 'b' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', in: ['b'] }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', in: ['b'] }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', lt: 'b' }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', lt: 'b' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', lte: 'b' }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', lte: 'b' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', gt: 'b' }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', gt: 'b' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', gte: 'b' }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', gte: 'b' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', between: ['b', 'c'] }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', between: ['b', 'c'] }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', exists: false }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', exists: false }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', contains: 'b' }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', contains: 'b' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', beginsWith: 'b' }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', beginsWith: 'b' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: 'b', type: 'string' }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', type: 'string' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`You can only supply one filter condition per query. Already using 'eq'`)
   })
 
   it('fails with unknown arguments', () => {
     expect(() =>
       // @ts-expect-error
-      expressionBuilder({ attr: 'a', eq: 'b', invalidArg: true }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: 'b', invalidArg: true }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`Invalid expression options: invalidArg`)
   })
 
   it('fails with invalid entity', () => {
-    expect(() => expressionBuilder({ attr: 'a', eq: 'b' }, TestTable, 'UnknownEntity')).toThrow(
+    expect(() => expressionBuilder({ attr: 'a', eq: 'b' }, TestTable, expressionId, 'UnknownEntity')).toThrow(
       `'entity' value of 'UnknownEntity' must be a string and a valid table Entity name`
     )
   })
 
   it('fails when no attr or size argument', () => {
-    expect(() => expressionBuilder({ eq: 'b' }, TestTable, 'TestEntity')).toThrow(
+    expect(() => expressionBuilder({ eq: 'b' }, TestTable, expressionId, 'TestEntity')).toThrow(
       `A string for 'attr' or 'size' is required for condition expressions`
     )
   })
 
   it('falls back to table attributes if no entity specified', () => {
-    const result = expressionBuilder({ attr: 'a', eq: 'b' }, TestTable)
+    const result = expressionBuilder({ attr: 'a', eq: 'b' }, TestTable, expressionId)
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it('uses size value and checks entity attribute', () => {
-    const result = expressionBuilder({ size: 'a', eq: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ size: 'a', eq: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('size(#attr1) = :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it('uses size value and checks nested entity attribute', () => {
-    const result = expressionBuilder({ size: 'a.b.c', eq: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ size: 'a.b.c', eq: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('size(#attr1_0.#attr1_1.#attr1_2) = :attr1')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it('uses size value and checks table attribute', () => {
-    const result = expressionBuilder({ size: 'a', eq: 'b' }, TestTable)
+    const result = expressionBuilder({ size: 'a', eq: 'b' }, TestTable, expressionId)
     expect(result.expression).toBe('size(#attr1) = :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it('uses size value and checks nested table attribute', () => {
-    const result = expressionBuilder({ size: 'a.b.c', eq: 'd' }, TestTable)
+    const result = expressionBuilder({ size: 'a.b.c', eq: 'd' }, TestTable, expressionId)
     expect(result.expression).toBe('size(#attr1_0.#attr1_1.#attr1_2) = :attr1')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it(`generates an 'eq' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', eq: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', eq: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 = :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`generates an 'eq' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', eq: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', eq: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1_0.#attr1_1.#attr1_2 = :attr1')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it(`generates an 'eq' clause with null/false values`, () => {
-    let result = expressionBuilder({ attr: 'a', eq: false }, TestTable, 'TestEntity')
+    let result = expressionBuilder({ attr: 'a', eq: false }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 = :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': false })
 
-    result = expressionBuilder({ attr: 'a', eq: null }, TestTable, 'TestEntity')
+    result = expressionBuilder({ attr: 'a', eq: null }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 = :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': null })
 
-    result = expressionBuilder({ attr: 'a', eq: '' }, TestTable, 'TestEntity')
+    result = expressionBuilder({ attr: 'a', eq: '' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 = :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': '' })
   })
 
   it(`generates a 'ne' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', ne: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', ne: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 <> :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`generates a 'ne' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', ne: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', ne: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1_0.#attr1_1.#attr1_2 <> :attr1')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it(`generates an 'ne' clause with null/false values`, () => {
-    let result = expressionBuilder({ attr: 'a', ne: false }, TestTable, 'TestEntity')
+    let result = expressionBuilder({ attr: 'a', ne: false }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 <> :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': false })
 
-    result = expressionBuilder({ attr: 'a', ne: null }, TestTable, 'TestEntity')
+    result = expressionBuilder({ attr: 'a', ne: null }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 <> :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': null })
 
-    result = expressionBuilder({ attr: 'a', ne: '' }, TestTable, 'TestEntity')
+    result = expressionBuilder({ attr: 'a', ne: '' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 <> :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': '' })
   })
 
   it(`generates an 'in' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', in: ['b', 'c'] }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', in: ['b', 'c'] }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 IN (:attr1_0,:attr1_1)')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1_0': 'b', ':attr1_1': 'c' })
   })
 
   it(`generates an 'in' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', in: ['d', 'e'] }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', in: ['d', 'e'] }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1_0.#attr1_1.#attr1_2 IN (:attr1_0,:attr1_1)')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1_0': 'd', ':attr1_1': 'e' })
   })
 
   it(`generates a 'lt' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', lt: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', lt: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 < :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`generates a 'lt' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', lt: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', lt: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1_0.#attr1_1.#attr1_2 < :attr1')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it(`generates a 'lte' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', lte: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', lte: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 <= :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`generates a 'lte' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', lte: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', lte: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1_0.#attr1_1.#attr1_2 <= :attr1')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it(`generates a 'gt' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', gt: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', gt: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 > :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`generates a 'gt' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', gt: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', gt: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1_0.#attr1_1.#attr1_2 > :attr1')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it(`generates a 'gte' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', gte: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', gte: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 >= :attr1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`generates a 'gte' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', gte: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', gte: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1_0.#attr1_1.#attr1_2 >= :attr1')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it(`generates a 'between' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', between: ['b', 'c'] }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', between: ['b', 'c'] }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 between :attr1_0 and :attr1_1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1_0': 'b', ':attr1_1': 'c' })
@@ -337,6 +344,7 @@ describe('expressionBuilder', () => {
     const result = expressionBuilder(
       { attr: 'a.b.c', between: ['d', 'e'] },
       TestTable,
+      expressionId,
       'TestEntity'
     )
     expect(result.expression).toBe('#attr1_0.#attr1_1.#attr1_2 between :attr1_0 and :attr1_1')
@@ -345,7 +353,7 @@ describe('expressionBuilder', () => {
   })
 
   it(`generates a 'between' clause with 'size'`, () => {
-    const result = expressionBuilder({ size: 'a', between: ['b', 'c'] }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ size: 'a', between: ['b', 'c'] }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('size(#attr1) between :attr1_0 and :attr1_1')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1_0': 'b', ':attr1_1': 'c' })
@@ -355,6 +363,7 @@ describe('expressionBuilder', () => {
     const result = expressionBuilder(
       { size: 'a.b.c', between: ['d', 'e'] },
       TestTable,
+      expressionId,
       'TestEntity'
     )
     expect(result.expression).toBe('size(#attr1_0.#attr1_1.#attr1_2) between :attr1_0 and :attr1_1')
@@ -363,65 +372,65 @@ describe('expressionBuilder', () => {
   })
 
   it(`generates an 'exists' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', exists: true }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', exists: true }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('attribute_exists(#attr1)')
     expect(result.names).toEqual({ '#attr1': 'a' })
   })
 
   it(`generates an 'exists' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', exists: true }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', exists: true }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('attribute_exists(#attr1_0.#attr1_1.#attr1_2)')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
   })
 
   it(`generates a 'not exists' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', exists: false }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', exists: false }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('attribute_not_exists(#attr1)')
     expect(result.names).toEqual({ '#attr1': 'a' })
   })
 
   it(`generates an 'not exists' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', exists: false }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', exists: false }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('attribute_not_exists(#attr1_0.#attr1_1.#attr1_2)')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
   })
 
   it(`generates a 'contains' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', contains: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', contains: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('contains(#attr1,:attr1)')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`generates a 'beginsWith' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', beginsWith: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', beginsWith: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('begins_with(#attr1,:attr1)')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`generates a 'beginsWith' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', beginsWith: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', beginsWith: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('begins_with(#attr1_0.#attr1_1.#attr1_2,:attr1)')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
   })
 
   it(`generates a 'type' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', type: 'b' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', type: 'b' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('attribute_type(#attr1,:attr1)')
     expect(result.names).toEqual({ '#attr1': 'a' })
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
   it(`references a secondary attribute in an 'eq' clause`, () => {
-    const result = expressionBuilder({ attr: 'a', eq: { attr: 'b' } }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a', eq: { attr: 'b' } }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('#attr1 = #attr1_ref')
     expect(result.names).toEqual({ '#attr1': 'a', '#attr1_ref': 'b' })
   })
 
   it(`generates a 'type' clause for a nested attribute`, () => {
-    const result = expressionBuilder({ attr: 'a.b.c', type: 'd' }, TestTable, 'TestEntity')
+    const result = expressionBuilder({ attr: 'a.b.c', type: 'd' }, TestTable, expressionId, 'TestEntity')
     expect(result.expression).toBe('attribute_type(#attr1_0.#attr1_1.#attr1_2,:attr1)')
     expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
     expect(result.values).toEqual({ ':attr1': 'd' })
@@ -429,51 +438,51 @@ describe('expressionBuilder', () => {
 
   it(`fails when 'between' value is not an array`, () => {
     // @ts-expect-error
-    expect(() => expressionBuilder({ attr: 'a', between: 'b' }, TestTable, 'TestEntity')).toThrow(
+    expect(() => expressionBuilder({ attr: 'a', between: 'b' }, TestTable, expressionId, 'TestEntity')).toThrow(
       `'between' conditions require an array with two values.`
     )
   })
 
   it(`fails when 'in' value is not an array`, () => {
     // @ts-expect-error
-    expect(() => expressionBuilder({ attr: 'a', in: 'b' }, TestTable, 'TestEntity')).toThrow(
+    expect(() => expressionBuilder({ attr: 'a', in: 'b' }, TestTable, expressionId, 'TestEntity')).toThrow(
       `'in' conditions require an array.`
     )
   })
 
   it(`fails when 'in' clause doesn't have an attr`, () => {
-    expect(() => expressionBuilder({ size: 'a', in: ['b'] }, TestTable, 'TestEntity')).toThrow(
+    expect(() => expressionBuilder({ size: 'a', in: ['b'] }, TestTable, expressionId, 'TestEntity')).toThrow(
       `'in' conditions require an 'attr'.`
     )
   })
 
   it(`fails when 'exists' clause doesn't have an attr`, () => {
-    expect(() => expressionBuilder({ size: 'a', exists: true }, TestTable, 'TestEntity')).toThrow(
+    expect(() => expressionBuilder({ size: 'a', exists: true }, TestTable, expressionId, 'TestEntity')).toThrow(
       `'exists' conditions require an 'attr'.`
     )
   })
 
   it(`fails when 'beginsWith' clause doesn't have an attr`, () => {
     expect(() =>
-      expressionBuilder({ size: 'a', beginsWith: 'b' }, TestTable, 'TestEntity')
+      expressionBuilder({ size: 'a', beginsWith: 'b' }, TestTable, expressionId, 'TestEntity')
     ).toThrow(`'beginsWith' conditions require an 'attr'.`)
   })
 
   it(`fails when 'contains' clause doesn't have an attr`, () => {
-    expect(() => expressionBuilder({ size: 'a', contains: 'b' }, TestTable, 'TestEntity')).toThrow(
+    expect(() => expressionBuilder({ size: 'a', contains: 'b' }, TestTable, expressionId, 'TestEntity')).toThrow(
       `'contains' conditions require an 'attr'.`
     )
   })
 
   it(`fails when 'type' clause doesn't have an attr`, () => {
-    expect(() => expressionBuilder({ size: 'a', type: 'b' }, TestTable, 'TestEntity')).toThrow(
+    expect(() => expressionBuilder({ size: 'a', type: 'b' }, TestTable, expressionId, 'TestEntity')).toThrow(
       `'type' conditions require an 'attr'.`
     )
   })
 
   it(`fails when 'value' type AttrRef is used without a property name`, () => {
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: { attr: '' } }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: { attr: '' } }, TestTable, expressionId, 'TestEntity')
     ).toThrow(
       `AttrRef must have an attr field which references another attribute in the same entity.`
     )
@@ -481,14 +490,14 @@ describe('expressionBuilder', () => {
 
   it(`fails when 'value' type AttrRef is used with a non-existing property name`, () => {
     expect(() =>
-      expressionBuilder({ attr: 'a', eq: { attr: 'nonexistent' } }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', eq: { attr: 'nonexistent' } }, TestTable, expressionId, 'TestEntity')
     ).toThrow('\'nonexistent\' is not a valid attribute within the given entity/table.')
   })
 
   it(`fails when 'value' type AttrRef is used with an unsupported operator`, () => {
     expect(() =>
       // @ts-expect-error
-      expressionBuilder({ attr: 'a', beginsWith: { attr: 'some-attr' } }, TestTable, 'TestEntity')
+      expressionBuilder({ attr: 'a', beginsWith: { attr: 'some-attr' } }, TestTable, expressionId, 'TestEntity')
     ).toThrow(
       `AttrRef is only supported for the following operators: ${SUPPORTED_FILTER_EXP_ATTR_REF_OPERATORS.join(
         ', '
@@ -497,22 +506,22 @@ describe('expressionBuilder', () => {
   })
 
   it(`fails when no condition is provided`, () => {
-    expect(() => expressionBuilder({ attr: 'a' }, TestTable, 'TestEntity')).toThrow(
+    expect(() => expressionBuilder({ attr: 'a' }, TestTable, expressionId, 'TestEntity')).toThrow(
       `A condition is required`
     )
   })
 
   it('allows 0 in comparaison expression', () => {
-    expect(() => expressionBuilder({ attr: 'a', lte: 0 }, TestTable, 'TestEntity')).not.toThrow(
+    expect(() => expressionBuilder({ attr: 'a', lte: 0 }, TestTable, expressionId, 'TestEntity')).not.toThrow(
       `A condition is required`
     )
-    expect(() => expressionBuilder({ attr: 'a', lt: 0 }, TestTable, 'TestEntity')).not.toThrow(
+    expect(() => expressionBuilder({ attr: 'a', lt: 0 }, TestTable, expressionId, 'TestEntity')).not.toThrow(
       `A condition is required`
     )
-    expect(() => expressionBuilder({ attr: 'a', gte: 0 }, TestTable, 'TestEntity')).not.toThrow(
+    expect(() => expressionBuilder({ attr: 'a', gte: 0 }, TestTable, expressionId, 'TestEntity')).not.toThrow(
       `A condition is required`
     )
-    expect(() => expressionBuilder({ attr: 'a', gt: 0 }, TestTable, 'TestEntity')).not.toThrow(
+    expect(() => expressionBuilder({ attr: 'a', gt: 0 }, TestTable, expressionId, 'TestEntity')).not.toThrow(
       `A condition is required`
     )
   })
@@ -520,8 +529,8 @@ describe('expressionBuilder', () => {
   it('doesn\'t mutate input expression', () => {
     const expObj = { attr: 'a', eq: 'b' }
     const expArr = [{ attr: 'a', eq: 'b' }]
-    expressionBuilder(expObj, TestTable, 'TestEntity')
-    expressionBuilder(expArr, TestTable, 'TestEntity')
+    expressionBuilder(expObj, TestTable, expressionId, 'TestEntity')
+    expressionBuilder(expArr, TestTable, expressionId, 'TestEntity')
     expect(expObj).toEqual({ attr: 'a', eq: 'b' })
     expect(expArr).toEqual([{ attr: 'a', eq: 'b' }])
   })

--- a/src/classes/Table/Table.ts
+++ b/src/classes/Table/Table.ts
@@ -25,6 +25,7 @@ import type {
   transactWriteParamsOptions,
 } from './types'
 
+import { ExpressionId } from '../../lib/expressionId'
 import { error, conditionError, If, Compute } from '../../lib/utils'
 import {
   BatchGetCommand,
@@ -515,6 +516,9 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       ..._args // capture extra arguments
     } = options
 
+    // Initialize the id generator
+    const expressionId = new ExpressionId()
+
     // Remove other valid options from options
     const args = Object.keys(_args).filter(x => !['execute', 'parse'].includes(x))
 
@@ -553,11 +557,11 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       select !== undefined &&
       (typeof select !== 'string' ||
         !['ALL_ATTRIBUTES', 'ALL_PROJECTED_ATTRIBUTES', 'SPECIFIC_ATTRIBUTES', 'COUNT'].includes(
-          select.toUpperCase(),
+          select.toUpperCase()
         ))
     ) {
       error(
-        `'select' must be one of 'ALL_ATTRIBUTES', 'ALL_PROJECTED_ATTRIBUTES', 'SPECIFIC_ATTRIBUTES', OR 'COUNT'`,
+        `'select' must be one of 'ALL_ATTRIBUTES', 'ALL_PROJECTED_ATTRIBUTES', 'SPECIFIC_ATTRIBUTES', OR 'COUNT'`
       )
     }
 
@@ -583,7 +587,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
 
     // Default names and values
     let ExpressionAttributeNames: { [key: string]: any } = {
-      '#pk': (index && this.Table.indexes[index].partitionKey) || this.Table.partitionKey,
+      '#pk': (index && this.Table.indexes[index].partitionKey) || this.Table.partitionKey
     }
     let ExpressionAttributeValues: { [key: string]: any } = { ':pk': pk }
     let KeyConditionExpression = '#pk = :pk'
@@ -674,7 +678,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
     // If filter expressions
     if (filters) {
       // Parse the filter
-      const { expression, names, values } = parseFilters(filters, this, entity)
+      const { expression, names, values } = parseFilters(filters, this, expressionId, entity)
 
       if (Object.keys(names).length > 0) {
         // TODO: alias attribute field names
@@ -693,7 +697,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
         attributes,
         this,
         entity!,
-        true,
+        true
       )
 
       if (Object.keys(names).length > 0) {
@@ -711,7 +715,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
         TableName: this.name,
         KeyConditionExpression,
         ExpressionAttributeNames,
-        ExpressionAttributeValues,
+        ExpressionAttributeValues
       },
       FilterExpression ? { FilterExpression } : null,
       ProjectionExpression ? { ProjectionExpression } : null,
@@ -722,7 +726,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       capacity ? { ReturnConsumedCapacity: capacity.toUpperCase() } : null,
       select ? { Select: select.toUpperCase() } : null,
       startKey ? { ExclusiveStartKey: startKey } : null,
-      typeof params === 'object' ? params : null,
+      typeof params === 'object' ? params : null
     )
 
     return projections ? { payload, EntityProjections, TableProjections } : payload
@@ -823,6 +827,9 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       ..._args // capture extra arguments
     } = options
 
+    // Initialize the id generator
+    const expressionId = new ExpressionId()
+
     // Remove other valid options from options
     const args = Object.keys(_args).filter(x => !['execute', 'parse'].includes(x))
 
@@ -850,11 +857,11 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       select !== undefined &&
       (typeof select !== 'string' ||
         !['ALL_ATTRIBUTES', 'ALL_PROJECTED_ATTRIBUTES', 'SPECIFIC_ATTRIBUTES', 'COUNT'].includes(
-          select.toUpperCase(),
+          select.toUpperCase()
         ))
     ) {
       error(
-        `'select' must be one of 'ALL_ATTRIBUTES', 'ALL_PROJECTED_ATTRIBUTES', 'SPECIFIC_ATTRIBUTES', OR 'COUNT'`,
+        `'select' must be one of 'ALL_ATTRIBUTES', 'ALL_PROJECTED_ATTRIBUTES', 'SPECIFIC_ATTRIBUTES', OR 'COUNT'`
       )
     }
 
@@ -888,7 +895,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       (!Number.isInteger(segment) || segment < 0 || segment >= segments!)
     ) {
       error(
-        `'segment' must be an integer greater than or equal to 0 and less than the total number of segments`,
+        `'segment' must be an integer greater than or equal to 0 and less than the total number of segments`
       )
     }
 
@@ -910,7 +917,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
     // If filter expressions
     if (filters) {
       // Parse the filter
-      const { expression, names, values } = parseFilters(filters, this, entity)
+      const { expression, names, values } = parseFilters(filters, this, expressionId, entity)
 
       if (Object.keys(names).length > 0) {
         // TODO: alias attribute field names
@@ -929,7 +936,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
         attributes,
         this,
         entity!,
-        true,
+        true
       )
 
       if (Object.keys(names).length > 0) {
@@ -944,7 +951,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
     // Generate the payload
     const payload = Object.assign(
       {
-        TableName: this.name,
+        TableName: this.name
       },
       Object.keys(ExpressionAttributeNames).length ? { ExpressionAttributeNames } : null,
       Object.keys(ExpressionAttributeValues).length ? { ExpressionAttributeValues } : null,
@@ -958,7 +965,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       capacity ? { ReturnConsumedCapacity: capacity.toUpperCase() } : null,
       select ? { Select: select.toUpperCase() } : null,
       startKey ? { ExclusiveStartKey: startKey } : null,
-      typeof params === 'object' ? params : null,
+      typeof params === 'object' ? params : null
     )
 
     return meta ? { payload, EntityProjections, TableProjections } : payload

--- a/src/lib/expressionId.ts
+++ b/src/lib/expressionId.ts
@@ -1,0 +1,19 @@
+export class ExpressionId {
+  i = 1
+
+  ids: Record<string, string> = {}
+
+  constructor(private prefix = 'attr') {}
+
+  get(key: string) {
+    const isValueOrName = key[0] === ':' || key[0] === '#'
+    const id = isValueOrName ? key.substring(1) : key
+    const prefix = isValueOrName ? key[0] : ''
+
+    if (!this.ids[id]) {
+      this.ids[id] = (this.i++).toString()
+    }
+
+    return `${prefix}${this.prefix}${this.ids[id]}`
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/jeremydaly/dynamodb-toolbox/issues/94

I've introduced a new `ExpressionId` class which will generate auto incrementing ids for expressions.