### PR TITLE
fix: esm build output

### DIFF
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
+    "module": "ESNext",
     "moduleResolution": "NodeNext",
     "noEmitHelpers": true,
     "outDir": "dist/esm",


### PR DESCRIPTION
Corrects the build configuration to properly output ESM format for the ESM build target,
instead of incorrectly generating CommonJS modules.

ref: https://cdn.jsdelivr.net/npm/dynamodb-toolbox@1.0.0/dist/esm/attributes/string/index.js