### PR TITLE
fix(docs): horizontal overflow on mobile

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -33,6 +33,7 @@
 
 .navbar {
   background-color: #303846;
+  height: unset;
 }
 
 .inline-block {
@@ -97,6 +98,11 @@
 
 .mt-2 {
   margin-top: 0.5rem;
+}
+
+.py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
 }
 
 .py-10 {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -380,9 +380,9 @@ const Home = (): JSX.Element => (
         </div>
       </div>
     </div>
-    <div className="navbar navbar--dark flex flex-col items-start justify-center py-10 text-sm shadow-xl shadow-black/10">
+    <div className="navbar navbar--dark flex flex-col items-start justify-center py-5 text-sm shadow-xl shadow-black/10">
       <div className="full-width">
-        <div className="flex justify-around md:justify-center gap-3">
+        <div className="flex justify-around md:justify-center md:flex-row flex-col gap-3">
           {footerLinks.map(item => (
             <div key={item.to} className="text-center">
               {item.to.startsWith('http') ? (


### PR DESCRIPTION
I was browsing through the docs and saw this visual bug on mobile, here's the fix 😊
Go to https://www.dynamodbtoolbox.com/ on mobile and scroll to the bottom to see the bug

### Before
<img width="561" alt="image" src="https://github.com/user-attachments/assets/6ef3875e-b537-4fc1-91dd-50bb8ce07156">

### After
<img width="540" alt="image" src="https://github.com/user-attachments/assets/63a21e77-0a03-4a5d-809f-e83feac9911f">
