### PR TITLE
Type documentation clarification: 'Note' instead of 'Not'

### DIFF
--- a/src/attributes/list/typer.ts
+++ b/src/attributes/list/typer.ts
@@ -19,7 +19,7 @@ type ListAttributeTyper = <
 
 /**
  * Define a new list attribute
- * Not that list elements have constraints. They must be:
+ * Note that list elements have constraints. They must be:
  * - Required (required: AtLeastOnce)
  * - Displayed (hidden: false)
  * - Not renamed (savedAs: undefined)

--- a/src/attributes/record/typer.ts
+++ b/src/attributes/record/typer.ts
@@ -22,7 +22,7 @@ type RecordAttributeTyper = <
 
 /**
  * Define a new record attribute
- * Not that record keys and elements have constraints. They must be:
+ * Note that record keys and elements have constraints. They must be:
  * - Required (required: AtLeastOnce)
  * - Displayed (hidden: false)
  * - Not key (key: false)

--- a/src/attributes/set/typer.ts
+++ b/src/attributes/set/typer.ts
@@ -19,7 +19,7 @@ type SetAttributeTyper = <
 
 /**
  * Define a new set attribute
- * Not that set elements have constraints. They must be:
+ * Note that set elements have constraints. They must be:
  * - Required (required: AtLeastOnce)
  * - Displayed (hidden: false)
  * - Not renamed (savedAs: undefined)


### PR DESCRIPTION
A very small one to clarify some type documentation (`record`, `set` and `list`).

The documentation now says
```
 * Note that record keys and elements have constraints. They must be:
 * - Required (required: AtLeastOnce)
 * - Displayed (hidden: false)
 * - Not key (key: false)
 * - Not renamed (savedAs: undefined)
 * - Not defaulted (defaults: undefined)
```

I'm not sure I understand that fully. The constraint "must be" hidden=false, but I can do this
```typescript
attr: record(string(), number(), { hidden: true })
```
and the [docs here](https://www.dynamodbtoolbox.com/docs/schemas/record#required) say
![image](https://github.com/user-attachments/assets/d8db62c2-3e60-4d62-a44b-02c0ec1b7c22)

In any case this PR avoids some confusion I got while reading the type doc :)

Thanks again for this amazing lib guys :snowman: