### PR TITLE
add preProcess to Table

### DIFF
--- a/src/entity/actions/get/getItemCommand.ts
+++ b/src/entity/actions/get/getItemCommand.ts
@@ -82,10 +82,17 @@ export class GetItemCommand<
       .getDocumentClient()
       .send(new GetCommand(getItemParams))
 
-    const { Item: item, ...restCommandOutput } = commandOutput
+    // TODO: investigate false positive
+    // eslint-disable-next-line prefer-const
+    let { Item: item, ...restCommandOutput } = commandOutput
 
     if (item === undefined) {
       return restCommandOutput
+    }
+
+    const { preProcess } = this.entity.table
+    if (preProcess) {
+      item = preProcess(item)
     }
 
     const { attributes } = this[$options]

--- a/src/entity/actions/transactGet/execute.ts
+++ b/src/entity/actions/transactGet/execute.ts
@@ -92,11 +92,18 @@ export const formatResponses: TransactGetResponseFormatter = <
     const transaction = transactions[index]!
     const transactionEntity = transaction.entity
     const { attributes } = transaction[$options]
+    const { preProcess } = transactionEntity.table
+
+    if (item === undefined) {
+      return { Item: item }
+    }
+
+    if (preProcess) {
+      item = preProcess(item)
+    }
 
     return {
-      Item: item
-        ? new EntityFormatter(transactionEntity).format(item, attributes ? { attributes } : {})
-        : undefined
+      Item: new EntityFormatter(transactionEntity).format(item, attributes ? { attributes } : {})
     }
   }) as TransactGetResponses<TRANSACTIONS>
 

--- a/src/table/actions/batchGet/execute.ts
+++ b/src/table/actions/batchGet/execute.ts
@@ -209,6 +209,7 @@ export const execute: ExecuteBatchGet = async <
       const tableName = command.table.getName()
       const requests = command[$requests]
       const { attributes } = (command as BatchGetCommand)[$options]
+      const { preProcess } = command.table
 
       return requests?.map((request, index) => {
         const entity = request.entity
@@ -224,12 +225,16 @@ export const execute: ExecuteBatchGet = async <
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const itemKey = initialRequestItems![tableName]!.Keys![index]!
 
-        const savedItem = tableResponses.find(tableResponse =>
+        let savedItem = tableResponses.find(tableResponse =>
           Object.entries(itemKey).every(([key, value]) => tableResponse[key] === value)
         )
 
         if (savedItem === undefined) {
           return undefined
+        }
+
+        if (preProcess) {
+          savedItem = preProcess(savedItem)
         }
 
         return entity.build(EntityFormatter).format(savedItem, { attributes })

--- a/src/table/actions/query/queryCommand.ts
+++ b/src/table/actions/query/queryCommand.ts
@@ -160,6 +160,7 @@ export class QueryCommand<
 
     // NOTE: maxPages has been validated by this.params()
     const { attributes, maxPages = 1 } = this[$options]
+    const { preProcess } = this.table
     let pageIndex = 0
     do {
       pageIndex += 1
@@ -179,7 +180,11 @@ export class QueryCommand<
         $metadata: pageMetadata
       } = await this.table.getDocumentClient().send(new _QueryCommand(pageQueryParams))
 
-      for (const item of items) {
+      for (let item of items) {
+        if (preProcess) {
+          item = preProcess(item)
+        }
+
         const itemEntityName = item[this.table.entityAttributeSavedAs]
 
         if (!isString(itemEntityName)) {

--- a/src/table/actions/scan/scanCommand.ts
+++ b/src/table/actions/scan/scanCommand.ts
@@ -123,6 +123,7 @@ export class ScanCommand<
 
     // NOTE: maxPages has been validated by this.params()
     const { attributes, maxPages = 1 } = this[$options]
+    const { preProcess } = this.table
     let pageIndex = 0
     do {
       pageIndex += 1
@@ -142,7 +143,11 @@ export class ScanCommand<
         $metadata: pageMetadata
       } = await this.table.getDocumentClient().send(new _ScanCommand(pageScanParams))
 
-      for (const item of items) {
+      for (let item of items) {
+        if (preProcess) {
+          item = preProcess(item)
+        }
+
         const itemEntityName = item[this.table.entityAttributeSavedAs]
 
         if (!isString(itemEntityName)) {

--- a/src/table/table.ts
+++ b/src/table/table.ts
@@ -20,7 +20,8 @@ export class Table<
   public partitionKey: PARTITION_KEY
   public sortKey?: SORT_KEY
   public indexes: INDEXES
-  public entityAttributeSavedAs: ENTITY_ATTRIBUTE_SAVED_AS;
+  public entityAttributeSavedAs: ENTITY_ATTRIBUTE_SAVED_AS
+  public preProcess?: (item: Record<string, any>) => Record<string, any>;
 
   [$interceptor]?: (action: TableSendableAction) => any
 
@@ -30,7 +31,8 @@ export class Table<
     partitionKey,
     sortKey,
     indexes = {} as INDEXES,
-    entityAttributeSavedAs = '_et' as ENTITY_ATTRIBUTE_SAVED_AS
+    entityAttributeSavedAs = '_et' as ENTITY_ATTRIBUTE_SAVED_AS,
+    preProcess
   }: {
     documentClient?: DynamoDBDocumentClient
     name?: string | (() => string)
@@ -38,6 +40,7 @@ export class Table<
     sortKey?: NarrowObject<SORT_KEY>
     indexes?: NarrowObjectRec<INDEXES>
     entityAttributeSavedAs?: ENTITY_ATTRIBUTE_SAVED_AS
+    preProcess?: (item: Record<string, any>) => Record<string, any>
   }) {
     this.documentClient = documentClient
     this.name = name
@@ -47,6 +50,7 @@ export class Table<
     }
     this.indexes = indexes as INDEXES
     this.entityAttributeSavedAs = entityAttributeSavedAs
+    this.preProcess = preProcess
   }
 
   getName(): string {


### PR DESCRIPTION
This is strawman proposal for #931 and I don't expect it to be merged as-is. I just find it easier to have a design discussion once you're looking at some real code.

It adds a `preProcess` option to the `Table` options which allows specifying a callback function to pre-process items before they go through the formatter.

Example usage:

``` ts
const FooTable = new Table({
	name: 'foo',
	partitionKey: { name: 'id', type: 'string' },
	preProcess(item) {
		// add entity to items created before dynamodb-toolbox migration
		item._et ??= 'FOO';
		// fix bad items created during XYZ
		if (typeof item.count === 'string') {
			item.count = Number.parseInt(item.count, 10);
		}
		return item;
	}
});
```

