### PR TITLE
Introducing DynamoDB-Toolbox Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     <img alt="" src="https://img.shields.io/github/license/dynamodb-toolbox/dynamodb-toolbox?color=%230e355b&style=for-the-badge">
   </a>
     <img alt="" src=https://img.shields.io/npm/dt/dynamodb-toolbox?color=%232e6ca9&style=for-the-badge>
+  <a aria-label="Gurubase" href="https://gurubase.io/g/dynamodb-toolbox">
+    <img alt="DynamoDB-Toolbox Guru Badge" src="https://img.shields.io/badge/Gurubase-Ask%20DynamoDB%20Toolbox%20Guru-006BFF?style=for-the-badge">
+  </a>
     <br/>
     <br/>
 </p>


### PR DESCRIPTION
Hello DynamoDB-Toolbox team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [DynamoDB-Toolbox Guru](https://gurubase.io/g/dynamodb-toolbox) to Gurubase. DynamoDB-Toolbox Guru uses the data from this repo and data from the [docs](https://www.dynamodbtoolbox.com/docs/getting-started/overview) to answer questions by leveraging the LLM.

In this PR, I showcased the "DynamoDB-Toolbox Guru" badge, which highlights that DynamoDB-Toolbox now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable DynamoDB-Toolbox Guru in Gurubase, just let me know that's totally fine.
