### PR TITLE
fix: DeleteItemCommands -> DeleteItemCommand in docs

### DIFF
--- a/docs/docs/3-entities/4-actions/14-transact-delete/index.md
+++ b/docs/docs/3-entities/4-actions/14-transact-delete/index.md
@@ -131,6 +131,6 @@ const transaction = PokemonEntity.build(DeleteTransaction)
 
 :::info
 
-Contrary to [`DeleteItemCommands`](../5-delete-item/index.md), delete transactions cannot return the values of the deleted items.
+Contrary to [`DeleteItemCommand`](../5-delete-item/index.md), delete transactions cannot return the values of the deleted items.
 
 :::

--- a/docs/docs/3-entities/4-actions/9-batch-delete/index.md
+++ b/docs/docs/3-entities/4-actions/9-batch-delete/index.md
@@ -46,6 +46,6 @@ const request = PokemonEntity.build(BatchDeleteRequest).key(
 
 :::info
 
-Contrary to [`DeleteItemCommands`](../5-delete-item/index.md), batch deletes cannot be [conditioned](../18-parse-condition/index.md), nor return the values of the deleted items.
+Contrary to [`DeleteItemCommand`](../5-delete-item/index.md), batch deletes cannot be [conditioned](../18-parse-condition/index.md), nor return the values of the deleted items.
 
 :::


### PR DESCRIPTION
Minor patch to this sentence: "Contrary to DeleteItemCommand**S** (no _-s_ here), batch deletes cannot be conditioned, nor return the values of the deleted items."