### PR TITLE
Add note to docs about customized timestamp from variable

### DIFF
--- a/docs/docs/3-entities/2-internal-attributes/index.md
+++ b/docs/docs/3-entities/2-internal-attributes/index.md
@@ -118,6 +118,12 @@ const PokemonEntity = new Entity({
 
 <h4 style={{ fontSize: "large" }}>Customizing Timestamps:</h4>
 
+:::info
+
+The customized timestamps options should be provided inline in the entity configuration, as in the examples below, to preserve correct types. When given as a variable, such as `timestamps: timestampConfig`, typescript types for the entity will be incorrect.
+
+:::
+
 Instead of `true`, you can provide an object to **fine-tune each attribute**. Available options:
 
 ### `name`


### PR DESCRIPTION
From #1071 :
> When customized timestamps is configured from a variable, the timestamps are missing from typescript types on the entity inputs and outputs.

This PR adds a warning in the customized timestamps documentation.