### PR TITLE
docs: add "Batching" examples

### DIFF
--- a/docs/docs/1-getting-started/4-examples/3-batching.md
+++ b/docs/docs/1-getting-started/4-examples/3-batching.md
@@ -1,0 +1,29 @@
+---
+title: Batching
+draft: true
+---
+
+# Batching
+
+In this guide, we’ll explore how to use the **BatchGet** and **BatchWrite** actions:
+
+- [**BatchGet**](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html) **retrieves** multiple items from one or more DynamoDB tables in a single request.
+- [**BatchWrite**](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html) **puts or deletes** multiple items in one or more DynamoDB tables in a single request.
+
+## Retrieving Multiple Items
+
+### Single Table, Single Entity
+
+### Single Table, Multiple Entities
+
+### Multiple Tables & Entities
+
+### Handling `BatchGetItem` Limits
+
+## Writing Multiple Items
+
+### Single Table
+
+### Multiple Tables
+
+### Handling `BatchWriteItem` Limits


### PR DESCRIPTION
This PR adds a "Batching" page to the "Examples" section on the documentation website. 