### PR TITLE
feat: 🏷️ add type completition and add strict matching after the schema path

### DIFF
--- a/src/schema/types/paths.ts
+++ b/src/schema/types/paths.ts
@@ -46,9 +46,9 @@ export type ItemSchemaPaths<SCHEMA extends ItemSchema = ItemSchema> = ItemSchema
       : never
     : never
 
-type AnySchemaPaths<SCHEMA_PATH extends string = string> =
-  | SCHEMA_PATH
-  | `${SCHEMA_PATH}${'.' | '['}${string}`
+type AnySchemaPaths<SCHEMA_PATH extends string = ''> = SCHEMA_PATH extends ''
+  ? string
+  : SCHEMA_PATH | `${SCHEMA_PATH}${'.' | '['}${string}`
 
 type ListSchemaPaths<
   SCHEMA extends ListSchema,

--- a/src/schema/types/paths.ts
+++ b/src/schema/types/paths.ts
@@ -46,10 +46,9 @@ export type ItemSchemaPaths<SCHEMA extends ItemSchema = ItemSchema> = ItemSchema
       : never
     : never
 
-type AnySchemaPaths<SCHEMA_PATH extends string = ''> =
-  | SCHEMA_PATH
-  | `${SCHEMA_PATH}.${string}`
-  | `${SCHEMA_PATH}[${string}`
+type AnySchemaPaths<SCHEMA_PATH extends string = ''> = SCHEMA_PATH extends ''
+  ? ''
+  : SCHEMA_PATH | `${SCHEMA_PATH}.${string}` | `${SCHEMA_PATH}[${string}`
 
 type ListSchemaPaths<
   SCHEMA extends ListSchema,

--- a/src/schema/types/paths.ts
+++ b/src/schema/types/paths.ts
@@ -46,7 +46,10 @@ export type ItemSchemaPaths<SCHEMA extends ItemSchema = ItemSchema> = ItemSchema
       : never
     : never
 
-type AnySchemaPaths<SCHEMA_PATH extends string = ''> = `${SCHEMA_PATH}${string}`
+type AnySchemaPaths<SCHEMA_PATH extends string = ''> =
+  | SCHEMA_PATH
+  | `${SCHEMA_PATH}.${string}`
+  | `${SCHEMA_PATH}[${string}`
 
 type ListSchemaPaths<
   SCHEMA extends ListSchema,

--- a/src/schema/types/paths.ts
+++ b/src/schema/types/paths.ts
@@ -46,9 +46,9 @@ export type ItemSchemaPaths<SCHEMA extends ItemSchema = ItemSchema> = ItemSchema
       : never
     : never
 
-type AnySchemaPaths<SCHEMA_PATH extends string = ''> = SCHEMA_PATH extends ''
-  ? ''
-  : SCHEMA_PATH | `${SCHEMA_PATH}.${string}` | `${SCHEMA_PATH}[${string}`
+type AnySchemaPaths<SCHEMA_PATH extends string = string> =
+  | SCHEMA_PATH
+  | `${SCHEMA_PATH}${'.' | '['}${string}`
 
 type ListSchemaPaths<
   SCHEMA extends ListSchema,

--- a/src/schema/types/paths.type.test.ts
+++ b/src/schema/types/paths.type.test.ts
@@ -44,7 +44,10 @@ const assertAttributePaths: A.Equals<
   | `['parentId']`
   | 'childId'
   | `['childId']`
-  | `${'any' | `['any']`}${string}`
+  | 'any'
+  | `['any']`
+  | `${'any' | `['any']`}.${string}`
+  | `${'any' | `['any']`}[${string}`
   | 'const'
   | `['const']`
   | 'num'


### PR DESCRIPTION
Add unions to the `AnySchemaPath` to allow autocomplete and enhance follow-up of that type by enforcing the use of a `.` or a `[` (which are the key selectors in Javascript)

Resolves #1163 