### PR TITLE
optionally merge options on AccessPattern

### DIFF
--- a/docs/docs/2-tables/2-actions/3-access-pattern/index.md
+++ b/docs/docs/2-tables/2-actions/3-access-pattern/index.md
@@ -105,6 +105,42 @@ const projectedPattern = PokeTable.build(AccessPattern)
   .options({ attributes: ['name', 'trainerId'] })
 ```
 
+:::note[Examples]
+
+<Tabs>
+<TabItem value="replace" label="Replace Options">
+
+```ts
+const pattern = PokeTable.build(AccessPattern)
+  .entities(TrainerEntity, PokemonEntity)
+  .options({ attributes: ['name', 'trainerId'] })
+
+// Replace existing options
+const newPattern = pattern.options({ reverse: true })
+// Result: { reverse: true } (attributes are lost)
+```
+
+</TabItem>
+<TabItem value="merge" label="Merge Options">
+
+```ts
+const pattern = PokeTable.build(AccessPattern)
+  .entities(TrainerEntity, PokemonEntity)
+  .options({ attributes: ['name', 'trainerId'] })
+
+// Merge with existing options
+const mergedPattern = pattern.options(
+  { reverse: true },
+  { merge: true }
+)
+// Result: { attributes: ['name', 'trainerId'], reverse: true }
+```
+
+</TabItem>
+</Tabs>
+
+:::
+
 :::info
 
 It is advised to provide `entities` first as it constrains the `options` type.

--- a/docs/docs/3-entities/4-actions/2-access-pattern/index.md
+++ b/docs/docs/3-entities/4-actions/2-access-pattern/index.md
@@ -100,6 +100,42 @@ const projectedPattern = PokemonEntity
   .options({ attributes: ['name', 'trainerId'] })
 ```
 
+:::note[Examples]
+
+<Tabs>
+<TabItem value="replace" label="Replace Options">
+
+```ts
+const pattern = PokemonEntity.build(AccessPattern).options({
+  attributes: ['name', 'trainerId']
+})
+
+// Replace existing options
+const newPattern = pattern.options({ reverse: true })
+// Result: { reverse: true } (attributes are lost)
+```
+
+</TabItem>
+<TabItem value="merge" label="Merge Options">
+
+```ts
+const pattern = PokemonEntity.build(AccessPattern).options({
+  attributes: ['name', 'trainerId']
+})
+
+// Merge with existing options
+const mergedPattern = pattern.options(
+  { reverse: true },
+  { merge: true }
+)
+// Result: { attributes: ['name', 'trainerId'], reverse: true }
+```
+
+</TabItem>
+</Tabs>
+
+:::
+
 ### `.meta(...)`
 
 Adds metadata to the `AccessPattern`.

--- a/src/entity/actions/accessPattern/accessPattern.ts
+++ b/src/entity/actions/accessPattern/accessPattern.ts
@@ -122,9 +122,20 @@ export class AccessPattern<
   }
 
   options<NEXT_OPTIONS extends QueryOptions<ENTITY['table'], [ENTITY], QUERY>>(
-    nextOptions: NEXT_OPTIONS
+    nextOptions: NEXT_OPTIONS,
+    options?: { merge?: boolean }
   ): AccessPattern<ENTITY, SCHEMA, QUERY, NEXT_OPTIONS> {
-    return new AccessPattern(this.entity, this[$schema], this[$pattern], nextOptions, this[$meta])
+    const potentiallyMergedOptions = options?.merge
+      ? { ...this[$options], ...nextOptions }
+      : nextOptions
+
+    return new AccessPattern(
+      this.entity,
+      this[$schema],
+      this[$pattern],
+      potentiallyMergedOptions,
+      this[$meta]
+    )
   }
 
   meta(nextMeta: AccessPatternMetadata): AccessPattern<ENTITY, SCHEMA, QUERY, OPTIONS> {

--- a/src/entity/actions/accessPattern/accessPattern.unit.test.ts
+++ b/src/entity/actions/accessPattern/accessPattern.unit.test.ts
@@ -89,6 +89,20 @@ describe('accessPattern', () => {
     expect(command[$options]).toStrictEqual({ attributes: ['age'] })
   })
 
+  test('builds query w. options and merge new options', () => {
+    const pk = TestEntity.build(AccessPattern)
+      .schema(string())
+      .pattern(partition => ({ partition }))
+      .options({ attributes: ['age'] })
+
+    const mergedPk = pk.options({ reverse: true }, { merge: true })
+
+    const command = mergedPk.query('123')
+
+    expect(command).toBeInstanceOf(QueryCommand)
+    expect(command[$options]).toStrictEqual({ attributes: ['age'], reverse: true })
+  })
+
   test('builds more complex query', () => {
     const eq = TestEntity.build(AccessPattern)
       .schema(map({ partition: string(), eq: string() }))

--- a/src/table/actions/accessPattern/accessPattern.ts
+++ b/src/table/actions/accessPattern/accessPattern.ts
@@ -146,14 +146,19 @@ export class AccessPattern<
   }
 
   options<NEXT_OPTIONS extends QueryOptions<TABLE, ENTITIES>>(
-    nextOptions: NEXT_OPTIONS
+    nextOptions: NEXT_OPTIONS,
+    options?: { merge?: boolean }
   ): AccessPattern<TABLE, ENTITIES, SCHEMA, QUERY, NEXT_OPTIONS> {
+    const potentiallyMergedOptions = options?.merge
+      ? { ...this[$options], ...nextOptions }
+      : nextOptions
+
     return new AccessPattern(
       this.table,
       this[$entities],
       this[$schema],
       this[$pattern],
-      nextOptions
+      potentiallyMergedOptions
     )
   }
 

--- a/src/table/actions/accessPattern/accessPattern.unit.test.ts
+++ b/src/table/actions/accessPattern/accessPattern.unit.test.ts
@@ -103,6 +103,21 @@ describe('accessPattern', () => {
     expect(command[$options]).toStrictEqual({ attributes: ['age', 'price'] })
   })
 
+  test('builds query w. options and merge new options', () => {
+    const pk = TestTable.build(AccessPattern)
+      .entities(Entity1, Entity2)
+      .schema(string())
+      .pattern(partition => ({ partition }))
+      .options({ attributes: ['age', 'price'] })
+
+    const mergedPk = pk.options({ reverse: true }, { merge: true })
+
+    const command = mergedPk.query('123')
+
+    expect(command).toBeInstanceOf(QueryCommand)
+    expect(command[$options]).toStrictEqual({ attributes: ['age', 'price'], reverse: true })
+  })
+
   test('builds more complex query', () => {
     const eq = TestTable.build(AccessPattern)
       .schema(map({ partition: string(), eq: string() }))


### PR DESCRIPTION
Allow chaining of AccessPattern options. This allows a library to pass an AccessPattern around and optionally add options like `reverse` or `exclusiveStartKey` conditionally.  

Where I need to use it: https://github.com/cranberyxl/apollo-cursor-pagination-ts/pull/3

```js
import { AccessPattern } from 'dynamodb-toolbox/entity/actions/accessPattern'

const highLevelPokemons = PokemonEntity.build(AccessPattern)
  // Define the expected query input schema
  .schema(map({ trainerId: string(), level: number() }))
  // Declare the query pattern
  .pattern(({ trainerId, level }) => ({
    index: 'byLevel',
    partition: trainerId,
    range: { gte: level }
  }))
  // Optional: provide additional options
  .options({ maxPages: 3 })


const methodThatDecidesDirection = (previousAccessPattern: AccessPatern) =>  {
  return previousAccessPattern.options({ reverse: true}, { merge: true });
}


// query is run with reverse: true
const { Items } = await methodThatDecidesDirection(highLevelPokemons)
  .query({ trainerId, level: 70 })
  .send()