### PR TITLE
fix(docs): bump engines.node to >=18.0.0 (matches CI matrix)

### DIFF
--- a/docs/docs/1-getting-started/2-installation/index.md
+++ b/docs/docs/1-getting-started/2-installation/index.md
@@ -4,7 +4,7 @@ title: Installation
 
 # Installation
 
-Requires Node.js 18 or later (ESM-only).
+Requires Node.js 18 or later.
 
 ```bash
 # npm

--- a/docs/docs/1-getting-started/2-installation/index.md
+++ b/docs/docs/1-getting-started/2-installation/index.md
@@ -4,6 +4,8 @@ title: Installation
 
 # Installation
 
+Requires Node.js 18 or later (ESM-only).
+
 ```bash
 # npm
 npm install dynamodb-toolbox

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "Naor Peled <me@naor.dev>"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "type": "module",
   "main": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

Bump `engines.node` from `>=14.0.0` to `>=18.0.0` and add a one-line install note.

## Why

- CI matrix in `.github/workflows/pull-request.yml` starts at Node 18 (no 14/16).
- `@types/node` devDep is `^18.0.0`.
- Package is `"type": "module"` (ESM-only); Node 14 had ESM behind a flag, so the package effectively needs a modern runtime.
- Node 14 is EOL (since 2023-04-30).

Misleading metadata: anyone reading `engines` will assume Node 14 works. The install docs don't mention a minimum Node version, so `engines` is the only signal.

## Changes

- `package.json`: `engines.node` → `>=18.0.0`
- `docs/docs/1-getting-started/2-installation/index.md`: add "Requires Node.js 18 or later (ESM-only)." above the install snippet

2 files, +3/-1. No behavior change for users on supported Node versions.

Fixes #1253