### PR TITLE
chore: override flatted to ^3.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4447,10 +4447,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
-      "dev": true
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -11602,14 +11603,14 @@
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.4.4",
         "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true
     },
     "for-each": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "express": "^5.2.1",
     "postcss": "^8.5.26",
     "brace-expansion": "^2.1.4",
-    "qs": "^6.15.3"
+    "qs": "^6.15.3",
+    "flatted": "^3.4.4"
   },
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": "^3.0.0",


### PR DESCRIPTION
## What

Overrides **`flatted`** to `^3.4.4`, clearing the two advisories dependabot flagged (#1284):
- unbounded-recursion DoS in `parse()` revive phase (`<3.4.0`)
- prototype pollution via `parse()` (`<=3.4.1`)

`flatted@3.2.2` was pulled transitively via `eslint@8 → flat-cache`. Dev/lint-only — nothing ships to consumers (published runtime dep is only `hotscript`).

## Verification
`npm run test-lint` passes (eslint runs clean with the bumped flatted).

Closes #1284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)