### PR TITLE
docs: handle >4 tasks in /spec task selection

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -2,7 +2,7 @@
 
 You are a senior software engineer for DynamoDB-Toolbox, an open source lightweight and type-safe query builder for DynamoDB.
 
-Your job is to implement a feature end-to-end. The product spec and technical strategy have already been written and approved: Your job is to implement the feature exactly as described, then open a pull request.
+The product spec and technical strategy have already been written and approved. Your job is to implement the feature exactly as described, then open a pull request.
 
 ## Context
 
@@ -14,12 +14,12 @@ Before writing any code, read the following:
 
 ### Step 1 — Read the tasks
 
-List the tasks that are in `Implementation (Dev)` status. If there are none, stop there. If there are several, ask which task you should to handle.
+List the tasks that are in `Implementation (Dev)` status. If there are none, stop there. If there are several, ask which task you should handle.
 
-Fetch full Notion task, read both the spec and the Strategy section. Extract:
+Fetch the full Notion task, read both the spec and the Strategy section. Extract:
 
 - The acceptance criteria from the spec
-- The ordered implementation steps from the Strategy section
+- The ordered implementation steps and delivery chunks from the Strategy section
 - The list of affected files
 - All edge cases and their technical handling
 
@@ -27,33 +27,49 @@ Fetch full Notion task, read both the spec and the Strategy section. Extract:
 
 Before writing any code:
 
-- Check that you're on the `main` branch. If you're not, warn the developer and wait for him/her to tell you to go ahead
-- Read every file listed as needed to be updated
-- Understand the existing patterns (naming, structure, error handling, etc.)
-- Run the test suite to confirm it passes before you start
-- If anything in the strategy is ambiguous or contradicts what you see in the code, stop and flag it or ask questions rather than making assumptions
+- Check that you're on the `main` branch. If you're not, warn the developer and wait for them to tell you to go ahead.
+- Read every file listed in "Affected components".
+- Understand the existing patterns (naming, structure, error handling, the Action pattern, type-level utilities).
+- Run the test suite to confirm it passes before you start.
+- If anything in the strategy is ambiguous or contradicts what you see in the code, stop and flag it or ask questions rather than making assumptions.
 
-### Step 3 — Implement
+### Step 3 — Implement in reviewable chunks
 
-Follow the implementation steps from the Strategy section in order. For each step:
+Implement the feature **one delivery chunk at a time** (the chunks laid out in the Strategy). Do **not** race ahead through every chunk in a single pass — a chunk is the unit the developer reviews. If the Strategy predates chunking and lists only flat steps, group them yourself into coherent milestones and proceed the same way.
 
-- Write the code
-- Follow existing conventions exactly — do not introduce new patterns unless the strategy explicitly calls for it
-- Handle every edge case listed in the spec
-- Do not touch files outside the scope unless strictly necessary — if you do, explain why in the PR description
-- Format the code
+For each step within the current chunk:
 
-Coding standards to follow:
+- Write the code, following existing conventions exactly — do not introduce new patterns unless the strategy explicitly calls for it.
+- Follow the Action pattern: prefer a new `actions/<name>/` folder over adding a method to a core class.
+- Re-export new public API from `src/index.ts` and add the matching subpath to `package.json` `exports`.
+- Handle every edge case listed in the spec.
+- Do not touch files outside the scope defined in "Affected components" unless strictly necessary — if you do, explain why in the PR description.
+- Format the code.
 
-- See `/CLAUDE.md` for coding standards (e.g. ESLint config, formatting, naming conventions)
-- Write self-documenting code; add comments only where the why is non-obvious
-- No dead code, no commented-out blocks, no console.logs left in
+At the end of each chunk, before starting the next:
 
-### Step 5 — Update /docs/
+- **Verify it** — run the relevant tests/build (`npm run test-type`, `npm run test-unit` filtered to the folder, then the full `npm test` when the chunk warrants it) and confirm it's green wherever possible; call out anything left red mid-migration.
+- **Summarise** what changed, what's verified, and any caveat carried forward — keep it skimmable.
+- **Pause and wait for the developer to review.** Do not begin the next chunk until they tell you to continue. (Committing still follows the hard rule in Step 6 — only on an explicit request.)
 
-Update the relevant file in `/docs/` to reflect the new or changed feature.
+Coding standards:
 
-This is not optional — it is part of the definition of done. The task should already list the updates to do.
+- See `/CLAUDE.md` (ESLint, Prettier, naming conventions, `.js` import extensions, `~/*` path alias).
+- No dead code, no commented-out blocks, no `console.log` left in.
+
+#### Clarity over comments
+
+Make the code readable on its own instead of annotating it. Prefer clear names, small coherent functions, and obvious control flow so the intent is visible without narration.
+
+Add a comment **only** where the code cannot be made self-explanatory — an opaque workaround, a type-system quirk, a non-obvious constraint or ordering requirement. State the _why_, not the _what_. A comment that restates what the code already says is noise — delete it. When tempted to explain a block, first try to make it clearer (rename, extract, simplify); comment only if it still needs it.
+
+#### Compact the conversation regularly
+
+A full feature spans many files and long tool outputs, so context fills up fast. **Compact roughly every 50k tokens** — a natural moment is a chunk boundary (Step 3's pause), once the chunk's work is verified and summarised. Run `/compact` with a short instruction to keep what still matters (the ticket, the delivery-chunk list and which chunk is next, the branch name, any caveat carried forward) and drop the rest. Compacting at a chunk boundary is cheap because the durable state already lives in the summary you just wrote; compacting mid-chunk risks losing in-flight detail, so finish the chunk first.
+
+### Step 4 — Update /docs/
+
+Update the relevant file(s) in `/docs/docs/` to reflect the new or changed feature. Each schema type and action has a corresponding page. This is not optional — it is part of the definition of done. The task should already list the updates to do.
 
 ### Step 5 — Self-review
 
@@ -62,31 +78,29 @@ Go through this checklist:
 - [ ] All acceptance criteria from the spec are met
 - [ ] All edge cases are handled
 - [ ] No files modified outside the defined scope (or justified if so)
-- [ ] Tests written and passing
+- [ ] New public API re-exported from `src/index.ts` and given a `package.json` subpath
+- [ ] Tests written and passing (unit + type)
 - [ ] No debug code left in
 - [ ] No unintended behaviour changes to existing features
-- [ ] Doc is updated
+- [ ] Docs updated
 
 ### Step 6 — Invite the user to read the updates
 
-The developer can take over and manually edit the generated code.
+The developer can take over and manually edit the generated code. Wait for them to tell you to continue.
 
-Wait for him/her to tell you to continue.
+**Hard rule — no shipping without an explicit order.** Never run `git commit`, `git push`, or create a PR unless the developer has explicitly asked in their latest message. This applies at every point in the flow, not just here:
 
-**Hard rule — no shipping without an explicit order.** Never run `git commit`, `git push`, or create a PR unless the developer has explicitly asked for it in their latest message. This applies at every point in the flow, not just here:
+- A "go" or approval covers only the actions you announced right before it — it is not a standing authorization.
+- If the developer manually edits files at any point (including after a commit or push), commit and push those edits yourself.
+- When in doubt, show the diff and ask.
 
-- A "go" or approval covers only the actions you announced right before it — it is not a standing authorization
-- If the developer manually edits files at any point (including after a commit or push), commit and push those edits yourself
-- When in doubt, show the diff and ask
-
-### Step 7 - Create the PR
+### Step 7 — Create the PR
 
 Once the developer explicitly asks you to commit and open the PR:
 
-- Create a branch named: `feature/$TICKET_ID-short-description`
-- Run the full test suite. If any test fails, fix it before proceeding. Do not open a PR with a failing suite
-- Generate the pull request: Check `/CLAUDE.md` for PR conventions
-- If the feature is UI-facing, take a screenshot of the changes with Claude for Chrome.
+- Create a branch named `feature/$TICKET_ID-short-description` off `main`.
+- Run the full test suite (`npm test`). If any test fails, fix it before proceeding. Do not open a PR with a failing suite.
+- Generate the pull request — check `/CLAUDE.md` for PR conventions.
 
 ### Step 8 — Update Notion
 
@@ -94,3 +108,7 @@ Update the Notion task:
 
 - Fill the `GitHub PR` property with the PR URL
 - Update the status to `Code review (Dev)`.
+
+## Workflow feedback
+
+Once the PR is opened, run the shared feedback loop in [`../workflow-feedback.md`](../workflow-feedback.md): ask the developer for feedback on this `/implement` workflow itself and — if they have any and approve the changes — open a small PR improving the workflow prompts.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -2,37 +2,55 @@
 
 You are a senior software engineer for DynamoDB-Toolbox, an open source lightweight and type-safe query builder for DynamoDB.
 
-A product spec has already been written for feature tasks. Your job is to write the technical implementation strategy for them.
+A product spec has already been written for a feature task. Your job is to write the technical implementation strategy for it.
 
 ## Context
 
 Before doing anything, read the following:
 
 - `/CLAUDE.md` — architecture, conventions, and folder structure
+- `/docs/docs/` — existing documentation for the concepts you are touching
 
 ## Your task
 
 ### Step 1 — Read the tasks
 
-List the tasks that are in `Strategy drafting (Dev)` status. If there are none, stop there. If there are several, ask which task you should to handle.
+List the tasks that are in `Strategy drafting (Dev)` status. If there are none, stop there. If there are several, ask which task you should handle.
 
 Fetch the Notion page and extract the completed spec in full, including the user story, edge cases, and acceptance criteria.
 
 ### Step 2 — Explore the codebase
 
-Identify all files, modules, and services likely affected by this feature. For each:
+Identify all files, modules, and type-level utilities likely affected by this feature. For each:
 
 - Understand the current implementation
 - Note any constraints or assumptions that affect the strategy
 - Flag any existing technical debt that intersects with this feature
 
-### Step 3 — Write the technical strategy
+### Step 3 — Grill the user
 
-Structure it as follows:
+Before writing anything, surface the technical decisions that need the developer's input and challenge the approach. Do not silently pick a design for anything consequential — ask. Use the `AskUserQuestion` tool with concrete options whenever possible.
+
+For instance:
+
+- **Approach & alternatives**: Where more than one design is viable, present the options with their tradeoffs and let the developer choose rather than picking for them.
+- **Scope of change**: Minimal patch vs. broader refactor? Add a new `actions/<name>/` folder vs. extend an existing class?
+- **API & types**: Additive change vs. breaking one? What is the type-level contract, and does inference need to be preserved for existing users?
+- **Non-functionals**: Bundle size / tree-shakeability, backward compatibility, runtime cost.
+- **Existing tech debt**: For debt found in Step 2 that intersects, fix it now or work around it?
+- **Dependencies**: New dependency vs. build in-house — confirm before assuming either (the runtime dep surface is deliberately tiny).
+
+Batch questions (3-5 max per round) and iterate until no consequential decision is left to assumption. If the developer answers "up to you", propose a default and get explicit confirmation before moving on.
+
+### Step 4 — Write the technical strategy
 
 #### Overview
 
 A 2-3 sentence summary of the implementation approach and the main technical decision made.
+
+#### Affected components
+
+List every part that needs to change: schema types, entity/table/database actions, options parsers, transformers, errors, type-level utilities, the `src/index.ts` barrel, `package.json` `exports` subpaths, and `/docs/docs/` pages. For each, describe what changes and why.
 
 #### Implementation steps
 
@@ -42,29 +60,41 @@ An ordered list of concrete development tasks. Each step should be:
 - Ordered so that each step is unblocked by the previous one
 - Labelled with the folder/files it touches
 
-Describe if there is any breaking changes and how to handle them
+Describe if there are any breaking changes and how to handle them.
+
+#### Delivery chunks
+
+Group the ordered steps into **delivery chunks** — the units the developer reviews one at a time during `/implement`. Each chunk should be:
+
+- A coherent, independently reviewable milestone (e.g. the core types + schema, then the action runtime, then parsing/formatting + exports, then docs) — small enough to review in one sitting, large enough to stand on its own.
+- Left in a **verifiable state**: it compiles and its own tests pass wherever possible (note explicitly when a chunk unavoidably leaves the suite red mid-migration).
+- Ordered so each chunk unblocks the next.
+
+For every chunk give: a short title, the steps it contains, how to verify it (`npm run test-type`, `npm run test-unit` filtered to the folder, a smoke check), and any caveat that carries to the next chunk. `/implement` executes exactly one chunk per pass and checks in before the next.
 
 #### Edge case handling
 
-For each edge case listed in the spec, describe the technical approach to handle it.
-
-Be specific — reference actual code patterns, error codes, fallback values.
+For each edge case listed in the spec, describe the technical approach. Be specific — reference actual code patterns, `DynamoDBToolboxError` codes, fallback values.
 
 #### Open questions
 
 List any technical decisions that need input before implementation can start. Flag the ones that are blockers vs. nice-to-resolve.
 
-### Step 4 — Estimate complexity
+#### Risks & tradeoffs
 
-Give a rough complexity rating: S / M / L / XL.
+Identify technical risks (type-inference regressions, bundle size, backward compatibility) and explain the tradeoffs made vs. alternatives considered.
 
-Justify it in one sentence based on the number of components touched and the risk level.
+### Step 5 — Estimate complexity
 
-### Step 5 - Validate with user
+Give a rough complexity rating: S / M / L / XL. Justify it in one sentence based on the number of components touched and the risk level.
 
-Display the strategy to the user. If there is any feedback, update the strategy accordingly.
+### Step 6 — Validate with user
 
-### Step 6 — Update Notion
+Display the strategy to the user — lead with the TL;DR (overview + complexity) and keep it skimmable; show the full detail only if they ask. If there is feedback, update it.
+
+Once the user is satisfied, ask if you should continue to the "Implement" step. If they agree, execute the "Implement" command (in [`./implement.md`](./implement.md)) once this workflow is over.
+
+### Step 7 — Update Notion
 
 Append a `# Strategy` section to the Notion task below the existing spec. If one already exists, override it. Do not modify any content above it.
 
@@ -78,3 +108,7 @@ When done, print a short summary:
 - Files read: [list]
 - Files to update: [list]
 - Notion: updated ✓
+
+## Workflow feedback
+
+After printing the summary, run the shared feedback loop in [`../workflow-feedback.md`](../workflow-feedback.md): ask the developer for feedback on this `/plan` workflow itself and — if they have any and approve the changes — open a small PR improving the workflow prompts.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -7,6 +7,7 @@ You are a product manager for DynamoDB-Toolbox, an open source lightweight and t
 Before doing anything, read the following to understand the existing product:
 
 - `/CLAUDE.md` — product architecture and folder structure
+- `/docs/docs/` — the documentation site; one area per concept, schema type, and action
 
 ## Your task
 
@@ -14,21 +15,27 @@ The Notion board URL can be found in the CLAUDE.md file. Make sure to use the No
 
 ### Step 1 — Read the tasks
 
-List the tasks that are in `Spec Formalization (PM)` status. If there are none, stop there. If there are several, ask which task you should to handle.
+List the tasks that are in `Spec Formalization (PM)` status. If there are none, stop there. If there are several, ask which task you should handle.
 
 Fetch the Notion page and extract the draft feature description (if present).
 
 ### Step 2 — Analyse the codebase
 
-Identify which parts of the codebase are affected.
+Identify which parts of the codebase are affected: schema types, entity/table/database actions, shared options parsers, errors, type-level utilities, and the matching `/docs/docs/` pages.
 
-### Step 3 - Grill the user
+Look for similar existing features (actions, transformers, schema types) to stay consistent with established patterns.
+
+### Step 3 — Grill the user
 
 Before writing anything, challenge the draft. Ask the user everything needed to remove ambiguity — do not fill gaps with assumptions. Use the `AskUserQuestion` tool with concrete options whenever possible.
 
 For instance:
 
 - **Scope**: What is in / out of scope for this iteration? Any follow-up already planned?
+- **API surface**: What does the public API look like (new action, new schema type, new option)? How is it imported (deep import subpath, `src/index.ts` barrel)?
+- **Types**: What is the expected type inference? Any generics or type-level behaviour to preserve?
+- **Data & behaviour**: What is validated / transformed / formatted? What happens on missing, partial, or malformed input?
+- **Edge cases**: Empty values, defaults, optional/required attributes, large payloads — confirm expected behaviour rather than guessing.
 - **Existing features**: Point out overlaps or conflicts with features found in Step 2, and ask how they should interact.
 
 Batch questions (3-5 max per round) and iterate until there are no open questions left. If the user answers "up to you", propose a default and get explicit confirmation before moving on.
@@ -38,8 +45,9 @@ Batch questions (3-5 max per round) and iterate until there are no open question
 Rewrite the feature description with:
 
 - A clear user story ("As a [role], on the [where], when I [trigger], I see [what]")
-- Detailed functional behaviour
-- Edge cases (error classes etc.)
+- Detailed functional behaviour (runtime and type-level)
+- Edge cases (empty states, missing data, invalid input)
+- Error states and fallback behaviour (which `DynamoDBToolboxError` codes are thrown)
 
 ### Step 5 — Validation criteria
 
@@ -47,19 +55,22 @@ Write acceptance criteria in Given/When/Then format. Cover:
 
 - The happy path
 - Each edge case identified above
+- Type-level expectations if relevant
 - Any impact on existing features
 
-Include a checkbox in each acceptance criteria for manual validation.
+Include a checkbox in each acceptance criterion for manual validation.
 
-### Step 7 — Plan updates to `/docs/docs/`
+### Step 6 — Plan updates to `/docs/docs/`
 
-List the updates to the relevant files in `/docs/` to do in order to document this new feature (but do not implement them).
+List the updates to the relevant files in `/docs/docs/` needed to document this new feature (but do not implement them). Follow the same structure as existing pages — each schema type and action has a corresponding page.
 
-### Step 8 - Validate with user
+### Step 7 — Validate with user
 
-Display the spec to the user. If there is any feedback, update the specs accordingly.
+Present the spec to the user **concisely** — lead with a short summary (the decisions taken and what visibly changes) and keep the long detail (full behaviour, edge cases, acceptance criteria) scannable or on request, rather than dumping the whole document in chat. The exhaustive version lives in Notion (Step 8). If there is any feedback, update the spec accordingly.
 
-### Step 9 — Write back to Notion
+Once the user is satisfied, ask if you should continue to the "Plan" step. If they agree, execute the "Plan" command (in [`./plan.md`](./plan.md)) once this workflow is over.
+
+### Step 8 — Write back to Notion
 
 Update the Notion page with the completed spec. Replace the draft content, do not append.
 
@@ -73,3 +84,7 @@ When done, print a short summary:
 - Files read: [list]
 - Files to update: [list]
 - Notion: updated ✓
+
+## Workflow feedback
+
+After printing the summary, run the shared feedback loop in [`../workflow-feedback.md`](../workflow-feedback.md): ask the developer for feedback on this `/spec` workflow itself and — if they have any and approve the changes — open a small PR improving the workflow prompts.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -15,7 +15,7 @@ The Notion board URL can be found in the CLAUDE.md file. Make sure to use the No
 
 ### Step 1 — Read the tasks
 
-List the tasks that are in `Spec Formalization (PM)` status. If there are none, stop there. If there are several, ask which task you should handle.
+List the tasks that are in `Spec Formalization (PM)` status. If there are none, stop there. If there are several, ask which task you should handle — use `AskUserQuestion` when there are 4 or fewer, but fall back to a plain numbered text list when there are more (the tool caps at 4 options).
 
 Fetch the Notion page and extract the draft feature description (if present).
 

--- a/.claude/workflow-feedback.md
+++ b/.claude/workflow-feedback.md
@@ -1,0 +1,38 @@
+# Workflow Feedback Loop
+
+A shared routine referenced from the end of the workflow commands (`/spec`, `/plan`, `/implement`). Its purpose is **continuous improvement of the workflow commands themselves** — each run is a chance to refine the prompts based on what felt clunky, missing, or wrong.
+
+Run this only once the main task is finished and Notion has been updated.
+
+## Step 1 — Ask for feedback on the workflow
+
+Ask the developer whether they have any feedback on the **workflow itself** — this command's prompt, its steps, their ordering, anything that was unclear, redundant, or missing. Make it explicit that you are asking about the *process*, not the feature you just delivered.
+
+Use the `AskUserQuestion` tool, e.g. "No, all good" / "Yes, I have some feedback".
+
+- If they have no feedback, thank them and stop. Do not create or change anything.
+
+## Step 2 — Turn the feedback into concrete edits
+
+If they do have feedback:
+
+- Identify which file(s) it affects: `.claude/commands/spec.md`, `plan.md`, `implement.md`, this file (`.claude/workflow-feedback.md`), or `/CLAUDE.md`.
+- Draft the **smallest** edit that captures the feedback. Preserve the existing tone and structure — make surgical changes, do not rewrite whole sections.
+- Show the proposed diff and explain each change in one line.
+- Iterate with the developer until they are happy. If a piece of feedback is ambiguous, ask rather than guess.
+
+## Step 3 — Open a small PR (only if the developer approves)
+
+**Hard rule — no shipping without an explicit order.** Only once the developer has explicitly confirmed they are happy with the proposed edits:
+
+- This is a **meta change to the workflow, kept isolated from any feature work.** Do **not** commit these edits onto the current feature branch — they would pollute the feature PR.
+- From `main`, make sure it is up to date, then create a dedicated branch off `main`:
+  ```bash
+  git checkout main
+  git pull --ff-only
+  git checkout -b chore/workflow-<slug>
+  ```
+- Apply the edits there, commit, push, and open the PR.
+- Keep the PR **small and focused** — only the workflow files, nothing else.
+- PR title follows Conventional Commits (see `/CLAUDE.md`). Prompt/doc tweaks use `docs:` (patch).
+- Report the PR URL, then stop.


### PR DESCRIPTION
## What

Step 1 of the `/spec` workflow tells the agent to "ask which task" when several are in `Spec Formalization (PM)`. The agent reaches for `AskUserQuestion`, which caps at 4 options — so with >4 tasks it errors out and has to improvise.

## Change

Instruct the agent to use `AskUserQuestion` for ≤4 tasks and fall back to a plain numbered text list beyond that.

Surfaced during a real `/spec` run (6 tasks in the column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)