### PR TITLE
fix: pass `any` and additional attributes by reference when parsing

### DIFF
--- a/docs/docs/4-schemas/5-any/index.md
+++ b/docs/docs/4-schemas/5-any/index.md
@@ -20,6 +20,12 @@ type Metadata = FormattedValue<typeof metadataSchema>
 // => unknown
 ```
 
+:::info
+
+`any` values are **not deep-cloned** during [parsing](../18-actions/1-parse.md): they are passed through **by reference**. This makes `any` safe for class instances and non-plain objects (e.g. `Date` or `Object.create(null)`), but means you should not mutate the input after parsing.
+
+:::
+
 ## Properties
 
 ### `.required()`

--- a/src/schema/actions/parse/any.ts
+++ b/src/schema/actions/parse/any.ts
@@ -1,6 +1,5 @@
 import type { AnySchema } from '~/schema/index.js'
 import type { Transformer } from '~/transformers/index.js'
-import { cloneDeep } from '~/utils/cloneDeep.js'
 
 import type { ParseAttrValueOptions } from './options.js'
 import type { ParserReturn, ParserYield } from './parser.js'
@@ -15,14 +14,14 @@ export function* anySchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
 
   let linkedValue = undefined
   if (fill) {
-    const defaultedValue = cloneDeep(inputValue)
+    const defaultedValue = inputValue
     yield defaultedValue
 
     linkedValue = defaultedValue
     yield linkedValue
   }
 
-  const parsedValue = linkedValue ?? cloneDeep(inputValue)
+  const parsedValue = linkedValue ?? inputValue
   if (parsedValue !== undefined) {
     applyCustomValidation(schema, parsedValue, options)
   }

--- a/src/schema/actions/parse/any.unit.test.ts
+++ b/src/schema/actions/parse/any.unit.test.ts
@@ -25,6 +25,17 @@ describe('anySchemaParser', () => {
     expect(done).toBe(true)
   })
 
+  test('preserves class instances by reference (does not deep-clone)', () => {
+    class Foo {
+      constructor(readonly bar: string) {}
+    }
+    const instance = new Foo('baz')
+
+    const { value } = anySchemaParser(any(), instance).next()
+    expect(value).toBe(instance)
+    expect(value).toBeInstanceOf(Foo)
+  })
+
   test('applies validation if any', () => {
     const anyA = any().validate(input => input === 'foo')
 

--- a/src/schema/actions/parse/item.ts
+++ b/src/schema/actions/parse/item.ts
@@ -39,7 +39,7 @@ export function* itemParser<SCHEMA extends ItemSchema, OPTIONS extends ParseValu
 
     restEntries = [...additionalAttributeNames.values()].map(attributeName => [
       attributeName,
-      cloneDeep(inputValue[attributeName])
+      inputValue[attributeName]
     ])
   }
 

--- a/src/schema/actions/parse/item.unit.test.ts
+++ b/src/schema/actions/parse/item.unit.test.ts
@@ -1,5 +1,5 @@
 import { DynamoDBToolboxError } from '~/errors/index.js'
-import { item, string } from '~/schema/index.js'
+import { any, item, string } from '~/schema/index.js'
 
 import * as schemaParserModule from './schema.js'
 import { itemParser } from './item.js'
@@ -45,6 +45,19 @@ describe('itemParser', () => {
 
     expect(invalidCall).toThrow(DynamoDBToolboxError)
     expect(invalidCall).toThrow(expect.objectContaining({ code: 'parsing.additionalProperty' }))
+  })
+
+  test('preserves additional attributes by reference (does not deep-clone)', () => {
+    class Foo {
+      constructor(readonly bar: string) {}
+    }
+    const instance = new Foo('baz')
+    const schema = item({ foo: string() })
+
+    const { value } = itemParser(schema, { foo: 'foo', extra: instance }).next()
+    const { extra } = value as { extra: unknown }
+    expect(extra).toBe(instance)
+    expect(extra).toBeInstanceOf(Foo)
   })
 
   describe('all modes', () => {

--- a/src/schema/actions/parse/map.ts
+++ b/src/schema/actions/parse/map.ts
@@ -37,7 +37,7 @@ export function* mapSchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
 
     restEntries = [...additionalAttributeNames.values()].map(attrName => [
       attrName,
-      cloneDeep(inputValue[attrName])
+      inputValue[attrName]
     ])
   }
 

--- a/src/schema/actions/parse/map.unit.test.ts
+++ b/src/schema/actions/parse/map.unit.test.ts
@@ -47,6 +47,19 @@ describe('mapSchemaParser', () => {
     expect(invalidCall).toThrow(expect.objectContaining({ code: 'parsing.additionalProperty' }))
   })
 
+  test('preserves additional attributes by reference (does not deep-clone)', () => {
+    class Foo {
+      constructor(readonly bar: string) {}
+    }
+    const instance = new Foo('baz')
+    const schema = map({ foo: string() })
+
+    const { value } = mapSchemaParser(schema, { foo: 'foo', extra: instance }).next()
+    const { extra } = value as { extra: unknown }
+    expect(extra).toBe(instance)
+    expect(extra).toBeInstanceOf(Foo)
+  })
+
   describe('all modes', () => {
     test('throws in update mode on an undeclared key', () => {
       const schema = map({ foo: string() }).strict()


### PR DESCRIPTION
## What

Stop deep-cloning **`any`-typed attribute values** and **additional (non-schema) pass-through attributes** during parsing — pass them **by reference** instead.

`cloneDeep` was applied to these unconstrained-type values, which was both unnecessary and unsafe:

- **Class instances** → silently flattened to plain objects, losing prototype and methods (data corruption).
- **`Object.create(null)`, `Map`, non-`Uint8Array` typed arrays, etc.** → threw `"Unable to clone object"` (`src/utils/cloneDeep.ts:34`) mid-parse.

## Changes

- `src/schema/actions/parse/any.ts` — both `cloneDeep(inputValue)` calls (fill + parsed paths) → `inputValue`; dropped the now-unused `cloneDeep` import.
- `src/schema/actions/parse/item.ts` — additional-attribute `cloneDeep(...)` → by reference (import kept, still used in the non-object branch).
- `src/schema/actions/parse/map.ts` — same.
- Tests: reference-preservation coverage for `any` values and for additional attributes on non-strict `item`/`map`.
- Docs: note on `docs/docs/4-schemas/5-any/index.md` that `any` values are not deep-cloned during parsing.

## Out of scope (deliberately untouched)

- `schema.ts:48` static-default clone — **kept** (prevents a static object default from being aliased across parsed items).
- `format/any.ts` read path — kept (DynamoDB never returns class instances).
- Mismatched-type `else`-branch clones (`primitive.ts`, list/tuple/set/map/record/item, `anyOf.ts`) — not `any`/additional attributes; optional future cleanup.

## Contract

- **Preserved:** parse never mutates the input.
- **New nuance (release note):** the parsed output may now share references with the input for `any` / additional attributes (no deep copy). Callers should not mutate the input after parsing while holding the output (and vice-versa). No type changes, no new error codes; the spurious-throw removal is strictly a bugfix.

## Verification

`npm test` green — type + unit (1485) + format + lint + exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)