### PR TITLE
feat(lint): enforce presence-only JSDoc on src/schema public API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,14 +9,28 @@
     "plugin:prettier/recommended",
     "prettier"
   ],
-  "plugins": ["@typescript-eslint", "prefer-arrow", "unused-imports", "prettier", "import"],
+  "plugins": [
+    "@typescript-eslint",
+    "prefer-arrow",
+    "unused-imports",
+    "prettier",
+    "import",
+    "jsdoc"
+  ],
   "parser": "@typescript-eslint/parser",
   "root": true,
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
+  "settings": {
+    "jsdoc": {
+      "mode": "typescript",
+      "definedTags": ["debt", "interceptable"]
+    }
+  },
   "rules": {
+    "jsdoc/require-jsdoc": "off",
     "import/extensions": ["error", "always"],
     "prettier/prettier": "error",
     "linebreak-style": ["error", "unix"],
@@ -47,7 +61,8 @@
     {
       "files": ["**/*.test.ts"],
       "rules": {
-        "@typescript-eslint/no-unused-vars": "off"
+        "@typescript-eslint/no-unused-vars": "off",
+        "jsdoc/require-jsdoc": "off"
       }
     }
   ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,6 +59,32 @@
   },
   "overrides": [
     {
+      "files": ["src/schema/**/*.ts"],
+      "rules": {
+        "jsdoc/require-jsdoc": [
+          "error",
+          {
+            "publicOnly": { "esm": true },
+            "enableFixer": false,
+            "exemptEmptyConstructors": true,
+            "require": {
+              "FunctionDeclaration": true,
+              "FunctionExpression": true,
+              "ArrowFunctionExpression": true,
+              "ClassDeclaration": true,
+              "ClassExpression": true
+            },
+            "contexts": [
+              "MethodDefinition:not([accessibility=\"private\"]):not([key.type=\"PrivateIdentifier\"])",
+              "TSTypeAliasDeclaration",
+              "TSInterfaceDeclaration",
+              "TSEnumDeclaration"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["**/*.test.ts"],
       "rules": {
         "@typescript-eslint/no-unused-vars": "off",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Reversible `{ encode, decode }` codecs applied to attribute values: `prefix`, `s
 - **Test files sit next to source:**
   - `*.unit.test.ts` — runtime unit tests (Vitest).
   - `*.type.test.ts` — type-level tests (`tsd` / `tsc`).
+- **JSDoc on public API.** `jsdoc/require-jsdoc` is enforced (`error`) for `src/schema/**` — every exported function, class, public method, type, interface and enum reachable from the barrel needs a `/** ... */` block. It's **presence-only**: a single short sentence is enough (e.g. `` Parse a value against a `set` schema. ``); wrap type/keyword names in backticks. Being rolled out folder-by-folder — other roots are still `off`.
 
 ## Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-jsdoc": "^50.8.0",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-unused-imports": "^4.2.0",
@@ -34,7 +35,7 @@
         "tsc-alias": "^1.8.10",
         "tsd": "^0.23.0",
         "tsx": "^4.23.12",
-        "typescript": "^5.9.3",
+        "typescript": "^5.9.2",
         "vite": "^6.4.3",
         "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^3.2.6",
@@ -849,6 +850,23 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
+      "integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6",
+        "@typescript-eslint/types": "^8.11.0",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2650,6 +2668,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3190,6 +3218,16 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/content-disposition": {
@@ -4001,6 +4039,73 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "50.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.50.2",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-prefer-arrow": {
@@ -5437,6 +5542,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6189,6 +6304,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -6206,6 +6331,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "5.1.1",
@@ -9386,6 +9518,19 @@
       "dev": true,
       "optional": true
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
+      "integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.6",
+        "@typescript-eslint/types": "^8.11.0",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      }
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.28.2",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
@@ -10419,6 +10564,12 @@
         }
       }
     },
+    "are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -10786,6 +10937,12 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
       "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
       "dev": true
     },
     "content-disposition": {
@@ -11413,6 +11570,53 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "50.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.50.2",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+          "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+          "dev": true
+        },
+        "espree": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+          "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.15.0",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^4.2.1"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+          "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
         }
       }
     },
@@ -12309,6 +12513,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsdoc-type-pratt-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -12840,6 +13050,15 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "requires": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -12851,6 +13070,12 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true
     },
     "parse5": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsdoc": "^50.8.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unused-imports": "^4.2.0",

--- a/src/schema/actions/dto/dto.ts
+++ b/src/schema/actions/dto/dto.ts
@@ -4,6 +4,9 @@ import { SchemaAction } from '~/schema/index.js'
 import { getSchemaDTO } from './getSchemaDTO/index.js'
 import type { ItemSchemaDTO } from './types.js'
 
+/**
+ * Serialize an item schema into a portable JSON DTO.
+ */
 export class SchemaDTO<SCHEMA extends ItemSchema = ItemSchema>
   extends SchemaAction<SCHEMA>
   implements ItemSchemaDTO
@@ -15,6 +18,9 @@ export class SchemaDTO<SCHEMA extends ItemSchema = ItemSchema>
   strict?: boolean | undefined
   meta?: SchemaMeta | undefined
 
+  /**
+   * Build the DTO from the item schema and its attributes.
+   */
   constructor(schema: SCHEMA) {
     super(schema)
     this.type = 'item'
@@ -28,6 +34,9 @@ export class SchemaDTO<SCHEMA extends ItemSchema = ItemSchema>
     this.meta = schema.props.meta
   }
 
+  /**
+   * Return the DTO as a plain JSON object.
+   */
   toJSON(): ItemSchemaDTO {
     const { strict, meta } = this
 

--- a/src/schema/actions/dto/getSchemaDTO/item.ts
+++ b/src/schema/actions/dto/getSchemaDTO/item.ts
@@ -3,6 +3,9 @@ import type { ItemSchema } from '~/schema/item/index.js'
 import type { ItemSchemaDTO } from '../types.js'
 import { getSchemaDTO } from './schema.js'
 
+/**
+ * Build the DTO of an `item` schema.
+ */
 export const getItemSchemaDTO = (schema: ItemSchema): ItemSchemaDTO => {
   const { strict, meta } = schema.props
 

--- a/src/schema/actions/dto/getSchemaDTO/schema.ts
+++ b/src/schema/actions/dto/getSchemaDTO/schema.ts
@@ -11,6 +11,9 @@ import { getRecordSchemaDTO } from './record.js'
 import { getSetSchemaDTO } from './set.js'
 import { getTupleSchemaDTO } from './tuple.js'
 
+/**
+ * Dispatch a schema to the DTO builder of its type.
+ */
 export const getSchemaDTO = (schema: Schema): ISchemaDTO => {
   /**
    * @debt feature "handle defaults, links & validators"

--- a/src/schema/actions/dto/getSchemaDTO/utils.ts
+++ b/src/schema/actions/dto/getSchemaDTO/utils.ts
@@ -3,6 +3,9 @@ import { isFunction } from '~/utils/validation/isFunction.js'
 
 import type { ISchemaDTO } from '../types.js'
 
+/**
+ * Extract a schema's key/put/update defaults into their DTO form.
+ */
 export const getDefaultsDTO = (
   schema: Schema
 ): Pick<ISchemaDTO, 'keyDefault' | 'putDefault' | 'updateDefault'> => {

--- a/src/schema/actions/dto/types.ts
+++ b/src/schema/actions/dto/types.ts
@@ -8,6 +8,9 @@ interface CustomTransformerDTO {
   transformerId: 'custom'
 }
 
+/**
+ * Serialized form of a transformer.
+ */
 export type TransformerDTO =
   | CustomTransformerDTO
   | JSONStringifierDTO
@@ -41,33 +44,57 @@ interface SchemaPropsDTO extends SchemaDefaultsDTO, SchemaLinksDTO {
   meta?: SchemaMeta
 }
 
+/**
+ * Transformers serializable on an `any` schema.
+ */
 export type AnySchemaTransformerDTO =
   | CustomTransformerDTO
   | JSONStringifierDTO
   | PipeDTO<TransformerDTO[]>
 
+/**
+ * DTO of an `any` schema.
+ */
 export interface AnySchemaDTO extends SchemaPropsDTO {
   type: 'any'
   transform?: AnySchemaTransformerDTO
 }
 
+/**
+ * Transformers serializable on a `null` schema.
+ */
 export type NullSchemaTransformerDTO = CustomTransformerDTO | PipeDTO<TransformerDTO[]>
 
+/**
+ * DTO of a `null` schema.
+ */
 export interface NullSchemaDTO extends SchemaPropsDTO {
   type: 'null'
   transform?: NullSchemaTransformerDTO
 }
 
+/**
+ * Transformers serializable on a `boolean` schema.
+ */
 export type BooleanSchemaTransformerDTO = CustomTransformerDTO | PipeDTO<TransformerDTO[]>
 
+/**
+ * DTO of a `boolean` schema.
+ */
 export interface BooleanSchemaDTO extends SchemaPropsDTO {
   type: 'boolean'
   enum?: boolean[]
   transform?: BooleanSchemaTransformerDTO
 }
 
+/**
+ * Transformers serializable on a `number` schema.
+ */
 export type NumberSchemaTransformerDTO = CustomTransformerDTO | PipeDTO<TransformerDTO[]>
 
+/**
+ * DTO of a `number` schema.
+ */
 export interface NumberSchemaDTO extends SchemaPropsDTO {
   type: 'number'
   big?: boolean
@@ -75,26 +102,41 @@ export interface NumberSchemaDTO extends SchemaPropsDTO {
   transform?: NumberSchemaTransformerDTO
 }
 
+/**
+ * Transformers serializable on a `string` schema.
+ */
 export type StringSchemaTransformerDTO =
   | CustomTransformerDTO
   | PrefixerDTO
   | SuffixerDTO
   | PipeDTO<TransformerDTO[]>
 
+/**
+ * DTO of a `string` schema.
+ */
 export interface StringSchemaDTO extends SchemaPropsDTO {
   type: 'string'
   enum?: string[]
   transform?: StringSchemaTransformerDTO
 }
 
+/**
+ * Transformers serializable on a `binary` schema.
+ */
 export type BinarySchemaTransformerDTO = CustomTransformerDTO | PipeDTO<TransformerDTO[]>
 
+/**
+ * DTO of a `binary` schema.
+ */
 export interface BinarySchemaDTO extends SchemaPropsDTO {
   type: 'binary'
   enum?: string[]
   transform?: BinarySchemaTransformerDTO
 }
 
+/**
+ * DTO of a primitive schema.
+ */
 export type PrimitiveSchemaDTO =
   | NullSchemaDTO
   | BooleanSchemaDTO
@@ -102,6 +144,9 @@ export type PrimitiveSchemaDTO =
   | StringSchemaDTO
   | BinarySchemaDTO
 
+/**
+ * DTO of a `set` schema.
+ */
 export interface SetSchemaDTO extends SchemaPropsDTO {
   type: 'set'
   elements: (NumberSchemaDTO | StringSchemaDTO | BinarySchemaDTO) & {
@@ -117,6 +162,9 @@ export interface SetSchemaDTO extends SchemaPropsDTO {
   }
 }
 
+/**
+ * DTO of a `list` schema.
+ */
 export interface ListSchemaDTO extends SchemaPropsDTO {
   type: 'list'
   elements: ISchemaDTO & {
@@ -132,6 +180,9 @@ export interface ListSchemaDTO extends SchemaPropsDTO {
   }
 }
 
+/**
+ * DTO of a `tuple` schema.
+ */
 export interface TupleSchemaDTO extends SchemaPropsDTO {
   type: 'tuple'
   elements: (ISchemaDTO & {
@@ -147,12 +198,18 @@ export interface TupleSchemaDTO extends SchemaPropsDTO {
   })[]
 }
 
+/**
+ * DTO of a `map` schema.
+ */
 export interface MapSchemaDTO extends SchemaPropsDTO {
   type: 'map'
   attributes: { [name: string]: ISchemaDTO }
   strict?: boolean
 }
 
+/**
+ * DTO of a `record` schema.
+ */
 export interface RecordSchemaDTO extends SchemaPropsDTO {
   type: 'record'
   keys: StringSchemaDTO & {
@@ -181,6 +238,9 @@ export interface RecordSchemaDTO extends SchemaPropsDTO {
   }
 }
 
+/**
+ * DTO of an `anyOf` schema.
+ */
 export interface AnyOfSchemaDTO extends SchemaPropsDTO {
   type: 'anyOf'
   elements: (ISchemaDTO & {
@@ -197,6 +257,9 @@ export interface AnyOfSchemaDTO extends SchemaPropsDTO {
   discriminator?: string
 }
 
+/**
+ * DTO of an `item` schema.
+ */
 export interface ItemSchemaDTO extends SchemaPropsDTO {
   type: 'item'
   attributes: {
@@ -216,6 +279,9 @@ export interface ItemSchemaDTO extends SchemaPropsDTO {
   strict?: boolean
 }
 
+/**
+ * DTO of any schema type.
+ */
 export type ISchemaDTO =
   | AnySchemaDTO
   | NullSchemaDTO

--- a/src/schema/actions/errors.ts
+++ b/src/schema/actions/errors.ts
@@ -4,6 +4,9 @@ import type { ParserErrorBlueprints } from './parse/errors.js'
 import type { ConditionParserErrorBlueprints } from './parseCondition/errors.js'
 import type { SchemaActionUtilsErrorBlueprints } from './utils/errors.js'
 
+/**
+ * Union of error blueprints raised by schema actions.
+ */
 export type ActionErrorBlueprints =
   | FormatterErrorBlueprints
   | ParserErrorBlueprints

--- a/src/schema/actions/finder/finder.ts
+++ b/src/schema/actions/finder/finder.ts
@@ -20,6 +20,9 @@ export class Finder<SCHEMA extends Schema = Schema> extends SchemaAction<SCHEMA>
   }
 }
 
+/**
+ * Recursively collect the sub-schemas found at a path within a schema.
+ */
 export const findSubSchemas = (schema: Schema, path: ArrayPath): SubSchema[] => {
   const [pathHead, ...pathTail] = path
 

--- a/src/schema/actions/finder/subSchema.ts
+++ b/src/schema/actions/finder/subSchema.ts
@@ -2,10 +2,16 @@ import type { Path } from '~/schema/actions/utils/path.js'
 import type { Schema } from '~/schema/index.js'
 import { SchemaAction } from '~/schema/index.js'
 
+/**
+ * A resolved sub-schema paired with its formatted and transformed paths.
+ */
 export class SubSchema<SCHEMA extends Schema = Schema> extends SchemaAction<SCHEMA> {
   readonly formattedPath: Path
   readonly transformedPath: Path
 
+  /**
+   * Instantiate from a schema and its formatted/transformed paths.
+   */
   constructor({
     schema,
     formattedPath,

--- a/src/schema/actions/format/any.ts
+++ b/src/schema/actions/format/any.ts
@@ -5,6 +5,9 @@ import { cloneDeep } from '~/utils/cloneDeep.js'
 import type { FormatterReturn, FormatterYield } from './formatter.js'
 import type { FormatAttrValueOptions } from './options.js'
 
+/**
+ * Format a saved value against an `any` schema.
+ */
 export function* anySchemaFormatter(
   schema: AnySchema,
   rawValue: unknown,

--- a/src/schema/actions/format/anyOf.ts
+++ b/src/schema/actions/format/anyOf.ts
@@ -9,6 +9,9 @@ import type { FormatterReturn, FormatterYield } from './formatter.js'
 import type { FormatAttrValueOptions } from './options.js'
 import { schemaFormatter } from './schema.js'
 
+/**
+ * Format a saved value against an `anyOf` schema.
+ */
 export function* anyOfSchemaFormatter(
   schema: AnyOfSchema,
   rawValue: unknown,

--- a/src/schema/actions/format/errors.ts
+++ b/src/schema/actions/format/errors.ts
@@ -31,6 +31,9 @@ type InvalidRawItemErrorBlueprint = ErrorBlueprint<{
   }
 }>
 
+/**
+ * Union of error blueprints raised by the formatter.
+ */
 export type FormatterErrorBlueprints =
   | RawAttributeRequiredErrorBlueprint
   | InvalidRawAttributeErrorBlueprint

--- a/src/schema/actions/format/formatter.ts
+++ b/src/schema/actions/format/formatter.ts
@@ -12,6 +12,9 @@ import { itemFormatter } from './item.js'
 import type { FormatValueOptions, InferReadValueOptions } from './options.js'
 import { schemaFormatter } from './schema.js'
 
+/**
+ * Values yielded by the formatter at each pipeline step.
+ */
 export type FormatterYield<
   SCHEMA extends Schema,
   OPTIONS extends FormatValueOptions<SCHEMA> = {},
@@ -20,6 +23,9 @@ export type FormatterYield<
   ? never
   : DecodedValue<SCHEMA, READ_VALUE_OPTIONS>
 
+/**
+ * Final value returned by the formatter.
+ */
 export type FormatterReturn<
   SCHEMA extends Schema,
   OPTIONS extends FormatValueOptions<SCHEMA> = {},
@@ -28,9 +34,15 @@ export type FormatterReturn<
   ? DecodedValue<SCHEMA, READ_VALUE_OPTIONS>
   : FormattedValue<SCHEMA, READ_VALUE_OPTIONS>
 
+/**
+ * Decodes and formats a saved value back to its app-facing shape.
+ */
 export class Formatter<SCHEMA extends Schema = Schema> extends SchemaAction<SCHEMA> {
   static override actionName = 'format' as const
 
+  /**
+   * Run the format pipeline lazily, yielding each intermediate step.
+   */
   start<OPTIONS extends FormatValueOptions<SCHEMA> = {}>(
     inputValue: unknown,
     options: OPTIONS = {} as OPTIONS
@@ -48,6 +60,9 @@ export class Formatter<SCHEMA extends Schema = Schema> extends SchemaAction<SCHE
     }
   }
 
+  /**
+   * Format a saved value into its app-facing shape.
+   */
   format<OPTIONS extends FormatValueOptions<SCHEMA> = {}>(
     inputValue: unknown,
     options: OPTIONS = {} as OPTIONS
@@ -66,6 +81,9 @@ export class Formatter<SCHEMA extends Schema = Schema> extends SchemaAction<SCHE
     return value
   }
 
+  /**
+   * Whether a value matches the schema's transformed (saved) form.
+   */
   validate(inputValue: unknown): inputValue is TransformedValue<SCHEMA> {
     try {
       this.format(inputValue, { format: false })

--- a/src/schema/actions/format/item.ts
+++ b/src/schema/actions/format/item.ts
@@ -7,6 +7,9 @@ import type { FormatValueOptions } from './options.js'
 import { schemaFormatter } from './schema.js'
 import { matchItemProjection } from './utils.js'
 
+/**
+ * Format a saved value against an `item` schema.
+ */
 export function* itemFormatter<OPTIONS extends FormatValueOptions<ItemSchema> = {}>(
   schema: ItemSchema,
   rawValue: unknown,

--- a/src/schema/actions/format/list.ts
+++ b/src/schema/actions/format/list.ts
@@ -8,6 +8,9 @@ import type { FormatAttrValueOptions } from './options.js'
 import { schemaFormatter } from './schema.js'
 import { matchListProjection } from './utils.js'
 
+/**
+ * Format a saved value against a `list` schema.
+ */
 export function* listSchemaFormatter(
   schema: ListSchema,
   rawValue: unknown,

--- a/src/schema/actions/format/map.ts
+++ b/src/schema/actions/format/map.ts
@@ -8,6 +8,9 @@ import type { FormatAttrValueOptions } from './options.js'
 import { schemaFormatter } from './schema.js'
 import { matchMapProjection } from './utils.js'
 
+/**
+ * Format a saved value against a `map` schema.
+ */
 export function* mapSchemaFormatter(
   schema: MapSchema,
   rawValue: unknown,

--- a/src/schema/actions/format/options.ts
+++ b/src/schema/actions/format/options.ts
@@ -1,6 +1,9 @@
 import type { ArrayPath } from '~/schema/actions/utils/types.js'
 import type { Paths, Schema } from '~/schema/index.js'
 
+/**
+ * Options driving how a value is formatted (projection, partial, reversal).
+ */
 export interface FormatValueOptions<SCHEMA extends Schema> {
   format?: boolean
   transform?: boolean
@@ -8,10 +11,16 @@ export interface FormatValueOptions<SCHEMA extends Schema> {
   partial?: boolean
 }
 
+/**
+ * Format options carrying the current value path within the recursion.
+ */
 export interface FormatAttrValueOptions<SCHEMA extends Schema> extends FormatValueOptions<SCHEMA> {
   valuePath?: ArrayPath
 }
 
+/**
+ * Derive the read-value options from user-provided format options.
+ */
 export interface InferReadValueOptions<
   SCHEMA extends Schema,
   OPTIONS extends FormatValueOptions<SCHEMA>

--- a/src/schema/actions/format/primitive.ts
+++ b/src/schema/actions/format/primitive.ts
@@ -7,6 +7,9 @@ import { isValidPrimitive } from '~/utils/validation/isValidPrimitive.js'
 import type { FormatterReturn, FormatterYield } from './formatter.js'
 import type { FormatAttrValueOptions } from './options.js'
 
+/**
+ * Format a saved value against a primitive schema.
+ */
 export function* primitiveSchemaFormatter(
   schema: PrimitiveSchema,
   rawValue: unknown,

--- a/src/schema/actions/format/record.ts
+++ b/src/schema/actions/format/record.ts
@@ -9,6 +9,9 @@ import type { FormatAttrValueOptions } from './options.js'
 import { schemaFormatter } from './schema.js'
 import { matchMapProjection } from './utils.js'
 
+/**
+ * Format a saved value against a record schema.
+ */
 export function* recordSchemaFormatter(
   schema: RecordSchema,
   rawValue: unknown,

--- a/src/schema/actions/format/schema.ts
+++ b/src/schema/actions/format/schema.ts
@@ -15,9 +15,15 @@ import { tupleSchemaFormatter } from './tuple.js'
 
 export const requiringOptions = new Set<SchemaRequiredProp>(['always', 'atLeastOnce'])
 
+/**
+ * Whether a schema must be present when formatting.
+ */
 export const isRequired = ({ props }: Schema): boolean =>
   requiringOptions.has(props.required ?? 'atLeastOnce')
 
+/**
+ * Dispatch a saved value to the formatter of its schema type.
+ */
 export function* schemaFormatter<
   SCHEMA extends Schema,
   OPTIONS extends FormatAttrValueOptions<SCHEMA> = {}

--- a/src/schema/actions/format/set.ts
+++ b/src/schema/actions/format/set.ts
@@ -7,6 +7,9 @@ import type { FormatterReturn, FormatterYield } from './formatter.js'
 import type { FormatAttrValueOptions } from './options.js'
 import { schemaFormatter } from './schema.js'
 
+/**
+ * Format a saved value against a `set` schema.
+ */
 export function* setSchemaFormatter(
   schema: SetSchema,
   rawValue: unknown,

--- a/src/schema/actions/format/tuple.ts
+++ b/src/schema/actions/format/tuple.ts
@@ -8,6 +8,9 @@ import type { FormatAttrValueOptions } from './options.js'
 import { schemaFormatter } from './schema.js'
 import { matchTupleProjection } from './utils.js'
 
+/**
+ * Format a saved value against a `tuple` schema.
+ */
 export function* tupleSchemaFormatter(
   schema: TupleSchema,
   rawValue: unknown,

--- a/src/schema/actions/format/utils.ts
+++ b/src/schema/actions/format/utils.ts
@@ -1,3 +1,6 @@
+/**
+ * Escape a string for safe use inside a projection regex.
+ */
 export const sanitize = (str: string): string =>
   str.replace(/\\/g, '\\\\').replace(/[-[\]/{}()*+?.^$|]/g, '\\$&')
 
@@ -5,6 +8,9 @@ type ProjectionMatch =
   | { isProjected: false; childrenAttributes?: never }
   | { isProjected: true; childrenAttributes?: string[] }
 
+/**
+ * Match a root item attribute against the projected attributes.
+ */
 export const matchItemProjection = (
   attributeName: string,
   projectedAttributes?: string[]
@@ -17,6 +23,9 @@ export const matchItemProjection = (
   )
 }
 
+/**
+ * Match a `map` attribute against the projected attributes.
+ */
 export const matchMapProjection = (
   attributeName: string,
   projectedAttributes?: string[]
@@ -29,9 +38,15 @@ export const matchMapProjection = (
   )
 }
 
+/**
+ * Match a `list` element against the projected attributes.
+ */
 export const matchListProjection = (projectedAttributes?: string[]): ProjectionMatch =>
   matchProjection(/\[\d+\]/, projectedAttributes)
 
+/**
+ * Match a `tuple` element against the projected attributes.
+ */
 export const matchTupleProjection = (
   elementIndex: number,
   projectedAttributes?: string[]

--- a/src/schema/actions/fromDTO/fromSchemaDTO.ts
+++ b/src/schema/actions/fromDTO/fromSchemaDTO.ts
@@ -4,6 +4,9 @@ import type { ItemSchema } from '~/schema/item/index.js'
 
 import { fromSchemaDTO as _fromSchemaDTO } from './fromSchemaDTO/index.js'
 
+/**
+ * Rebuild an `item` schema from its DTO.
+ */
 export const fromSchemaDTO = (schemaDTO: ItemSchemaDTO): ItemSchema => {
   let schema = item(
     Object.fromEntries(

--- a/src/schema/actions/fromDTO/fromSchemaDTO/attribute.ts
+++ b/src/schema/actions/fromDTO/fromSchemaDTO/attribute.ts
@@ -11,6 +11,9 @@ import { fromRecordSchemaDTO } from './record.js'
 import { fromSetSchemaDTO } from './set.js'
 import { fromTupleSchemaDTO } from './tuple.js'
 
+/**
+ * Dispatch a DTO to the schema builder of its type.
+ */
 export const fromSchemaDTO = (schemaDTO: ISchemaDTO): Schema => {
   switch (schemaDTO.type) {
     case 'any':

--- a/src/schema/actions/fromDTO/fromSchemaDTO/transformer.ts
+++ b/src/schema/actions/fromDTO/fromSchemaDTO/transformer.ts
@@ -5,6 +5,9 @@ import { prefix } from '~/transformers/prefix.js'
 import { suffix } from '~/transformers/suffix.js'
 import type { Transformer } from '~/transformers/transformer.js'
 
+/**
+ * Rehydrate a serializable transformer from its DTO.
+ */
 export const fromTransformerDTO = (transformerDTO: TransformerDTO): Transformer | null => {
   try {
     switch (transformerDTO.transformerId) {

--- a/src/schema/actions/fromZodSchema/errors.ts
+++ b/src/schema/actions/fromZodSchema/errors.ts
@@ -16,6 +16,9 @@ type UnsupportedSetValueTypeErrorBlueprint = ErrorBlueprint<{
   }
 }>
 
+/**
+ * Union of error blueprints raised when converting a `zod` schema.
+ */
 export type FromZodSchemaErrorBlueprints =
   | UnrecognizedLiteralErrorBlueprint
   | UnsupportedSetValueTypeErrorBlueprint

--- a/src/schema/actions/fromZodSchema/fromZodSchema.ts
+++ b/src/schema/actions/fromZodSchema/fromZodSchema.ts
@@ -116,6 +116,9 @@ type FromZodGeneralSchema<
   PROPS extends SchemaProps = {}
 > = FromZodCustom<ZOD_SCHEMA, ROOT, PROPS>
 
+/**
+ * DDB-TB schema derived from a `zod` schema.
+ */
 export type FromZodSchema<
   ZOD_SCHEMA extends ZodSchema,
   ROOT extends boolean = true,
@@ -126,6 +129,9 @@ export type FromZodSchema<
     ? FromZodGeneralSchema<ZOD_SCHEMA, ROOT, PROPS>
     : never
 
+/**
+ * DDB-TB schemas derived from a tuple of `zod` schemas.
+ */
 export type FromZodSchemaRec<
   ZOD_SCHEMAS extends readonly ZodSchema[],
   ROOT extends boolean = true,
@@ -143,6 +149,9 @@ export type FromZodSchemaRec<
     >
   : RESULT_SCHEMAS
 
+/**
+ * Convert a `zod` schema to a DDB-TB schema.
+ */
 export const fromZodSchema = <ZOD_SCHEMA extends ZodSchema>(
   zodSchema: ZOD_SCHEMA
 ): FromZodSchema<ZOD_SCHEMA> => {

--- a/src/schema/actions/fromZodSchema/utils.ts
+++ b/src/schema/actions/fromZodSchema/utils.ts
@@ -2,6 +2,9 @@ import type { ZodType } from 'zod'
 
 import type { Schema, Schema_ } from '~/schema/types/schema.js'
 
+/**
+ * Carry a `zod` schema's description onto a DDB-TB schema.
+ */
 export const withMeta = <SCHEMA extends Schema>(
   schema: SCHEMA,
   { description }: ZodType

--- a/src/schema/actions/fromZodSchema/zodArray.ts
+++ b/src/schema/actions/fromZodSchema/zodArray.ts
@@ -8,8 +8,14 @@ import type { FromZodSchema } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` array schema.
+ */
 export type ZodArrayAny = ZodArray<ZodTypeAny, ArrayCardinality>
 
+/**
+ * DDB-TB schema derived from a `zod` array schema.
+ */
 export type FromZodArray<
   ZOD_SCHEMA extends ZodArrayAny,
   ROOT extends boolean = true,
@@ -21,5 +27,8 @@ export type FromZodArray<
       : ListSchema<FromZodSchema<ELEMENT_ZOD_SCHEMAS, false>, PROPS>
     : never
 
+/**
+ * Convert a `zod` array schema to a DDB-TB schema.
+ */
 export const fromZodArray = (zodArray: ZodArrayAny): ListSchema =>
   withMeta(list(fromZodSchema(zodArray.element)), zodArray)

--- a/src/schema/actions/fromZodSchema/zodBigInt.ts
+++ b/src/schema/actions/fromZodSchema/zodBigInt.ts
@@ -7,6 +7,9 @@ import type { Overwrite } from '~/types/overwrite.js'
 
 import { withMeta } from './utils.js'
 
+/**
+ * DDB-TB schema derived from a `zod` bigint schema.
+ */
 export type FromZodBigInt<
   ROOT extends boolean = true,
   PROPS extends SchemaProps = {}
@@ -14,5 +17,8 @@ export type FromZodBigInt<
   ? NumberSchema_<Overwrite<PROPS, { big: true }>>
   : NumberSchema<Overwrite<PROPS, { big: true }>>
 
+/**
+ * Convert a `zod` bigint schema to a DDB-TB schema.
+ */
 export const fromZodBigInt = (zodSchema: ZodBigInt): NumberSchema =>
   withMeta(number({ big: true }), zodSchema)

--- a/src/schema/actions/fromZodSchema/zodBoolean.ts
+++ b/src/schema/actions/fromZodSchema/zodBoolean.ts
@@ -6,10 +6,16 @@ import type { SchemaProps } from '~/schema/types/schemaProps.js'
 
 import { withMeta } from './utils.js'
 
+/**
+ * DDB-TB schema derived from a `zod` boolean schema.
+ */
 export type FromZodBoolean<
   ROOT extends boolean = true,
   PROPS extends SchemaProps = {}
 > = ROOT extends true ? BooleanSchema_<PROPS> : BooleanSchema<PROPS>
 
+/**
+ * Convert a `zod` boolean schema to a DDB-TB schema.
+ */
 export const fromZodBoolean = (zodSchema: ZodBoolean): BooleanSchema =>
   withMeta(boolean(), zodSchema)

--- a/src/schema/actions/fromZodSchema/zodCustom.ts
+++ b/src/schema/actions/fromZodSchema/zodCustom.ts
@@ -7,6 +7,9 @@ import type { Overwrite } from '~/types/overwrite.js'
 
 import { withMeta } from './utils.js'
 
+/**
+ * DDB-TB `any` schema derived from an arbitrary `zod` schema.
+ */
 export type FromZodCustom<
   ZOD_SCHEMA extends ZodType,
   ROOT extends boolean = true,
@@ -23,4 +26,7 @@ export type FromZodCustom<
         : Overwrite<PROPS, { castAs: ZOD_SCHEMA['_output'] }>
     >
 
+/**
+ * Convert an arbitrary `zod` schema to a DDB-TB `any` schema.
+ */
 export const fromZodCustom = (zodSchema: ZodType): AnySchema => withMeta(any(), zodSchema)

--- a/src/schema/actions/fromZodSchema/zodDefault.ts
+++ b/src/schema/actions/fromZodSchema/zodDefault.ts
@@ -8,8 +8,14 @@ import type { FromZodSchema } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` default schema.
+ */
 export type ZodDefaultAny = ZodDefault<ZodTypeAny>
 
+/**
+ * DDB-TB schema derived from a `zod` default schema.
+ */
 export type FromZodDefault<
   ZOD_SCHEMA extends ZodDefaultAny,
   ROOT extends boolean = true,
@@ -19,6 +25,9 @@ export type FromZodDefault<
     ? FromZodSchema<UNWRAPPED_ZOD_SCHEMA, ROOT, Overwrite<PROPS, { putDefault: unknown }>>
     : never
 
+/**
+ * Convert a `zod` default schema to a DDB-TB schema.
+ */
 export const fromZodDefault = (zodSchema: ZodDefaultAny): Schema =>
   withMeta(
     fromZodSchema(zodSchema.removeDefault()).default(zodSchema._def.defaultValue()),

--- a/src/schema/actions/fromZodSchema/zodDiscriminatedUnion.ts
+++ b/src/schema/actions/fromZodSchema/zodDiscriminatedUnion.ts
@@ -9,11 +9,17 @@ import type { FromZodSchemaRec } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` discriminated union schema.
+ */
 export type ZodDiscriminatedUnionAny = ZodDiscriminatedUnion<
   string,
   ZodDiscriminatedUnionOption<string>[]
 >
 
+/**
+ * DDB-TB schema derived from a `zod` discriminated union schema.
+ */
 export type FromZodDiscriminatedUnion<
   ZOD_SCHEMA extends ZodDiscriminatedUnionAny,
   ROOT extends boolean = true,
@@ -31,6 +37,9 @@ export type FromZodDiscriminatedUnion<
         >
     : never
 
+/**
+ * Convert a `zod` discriminated union schema to a DDB-TB schema.
+ */
 export const fromZodDiscriminatedUnion = (
   zodDiscriminatedUnion: ZodDiscriminatedUnionAny
 ): AnyOfSchema =>

--- a/src/schema/actions/fromZodSchema/zodEffects.ts
+++ b/src/schema/actions/fromZodSchema/zodEffects.ts
@@ -8,8 +8,14 @@ import type { FromZodSchema } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` effects schema.
+ */
 export type ZodEffectsAny = ZodEffects<ZodTypeAny>
 
+/**
+ * DDB-TB schema derived from a `zod` effects schema.
+ */
 export type FromZodEffects<
   ZOD_SCHEMA extends ZodEffectsAny,
   ROOT extends boolean = true,
@@ -19,6 +25,9 @@ export type FromZodEffects<
     ? FromZodSchema<UNWRAPPED_ZOD_SCHEMA, ROOT, Overwrite<PROPS, { putValidator: Validator }>>
     : never
 
+/**
+ * Convert a `zod` effects schema to a DDB-TB schema.
+ */
 export const fromZodEffects = (zodSchema: ZodEffectsAny): Schema => {
   const schema = fromZodSchema(zodSchema._def.schema)
   const effect = zodSchema._def.effect

--- a/src/schema/actions/fromZodSchema/zodEnum.ts
+++ b/src/schema/actions/fromZodSchema/zodEnum.ts
@@ -7,8 +7,14 @@ import type { Overwrite } from '~/types/overwrite.js'
 
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` enum schema.
+ */
 export type ZodEnumAny = ZodEnum<[string, ...string[]]>
 
+/**
+ * DDB-TB schema derived from a `zod` enum schema.
+ */
 export type FromZodEnum<
   ZOD_SCHEMA extends ZodEnumAny,
   ROOT extends boolean = true,
@@ -20,5 +26,8 @@ export type FromZodEnum<
       : StringSchema<Overwrite<PROPS, { enum: ZOD_SCHEMA_ENUM }>>
     : never
 
+/**
+ * Convert a `zod` enum schema to a DDB-TB schema.
+ */
 export const fromZodEnum = (zodEnum: ZodEnumAny): StringSchema =>
   withMeta(string().enum(...zodEnum.options), zodEnum)

--- a/src/schema/actions/fromZodSchema/zodLiteral.ts
+++ b/src/schema/actions/fromZodSchema/zodLiteral.ts
@@ -25,8 +25,14 @@ import { isString } from '~/utils/validation/isString.js'
 
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` literal schema.
+ */
 export type ZodLiteralAny = ZodLiteral<any>
 
+/**
+ * DDB-TB schema derived from a `zod` literal schema.
+ */
 export type FromZodLiteral<
   ZOD_SCHEMA extends ZodLiteralAny,
   ROOT extends boolean = true,
@@ -67,6 +73,9 @@ export type FromZodLiteral<
             : never)
     : never
 
+/**
+ * Convert a `zod` literal schema to a DDB-TB schema.
+ */
 export const fromZodLiteral = (
   zodLiteral: ZodLiteralAny
 ): NullSchema | BooleanSchema | NumberSchema | StringSchema => {

--- a/src/schema/actions/fromZodSchema/zodNull.ts
+++ b/src/schema/actions/fromZodSchema/zodNull.ts
@@ -6,9 +6,15 @@ import type { SchemaProps } from '~/schema/types/schemaProps.js'
 
 import { withMeta } from './utils.js'
 
+/**
+ * DDB-TB schema derived from a `zod` null schema.
+ */
 export type FromZodNull<
   ROOT extends boolean = true,
   PROPS extends SchemaProps = {}
 > = ROOT extends true ? NullSchema_<PROPS> : NullSchema<PROPS>
 
+/**
+ * Convert a `zod` null schema to a DDB-TB schema.
+ */
 export const fromZodNull = (zodSchema: ZodNull): NullSchema => withMeta(nul(), zodSchema)

--- a/src/schema/actions/fromZodSchema/zodNumber.ts
+++ b/src/schema/actions/fromZodSchema/zodNumber.ts
@@ -6,9 +6,15 @@ import type { SchemaProps } from '~/schema/types/schemaProps.js'
 
 import { withMeta } from './utils.js'
 
+/**
+ * DDB-TB schema derived from a `zod` number schema.
+ */
 export type FromZodNumber<
   ROOT extends boolean = true,
   PROPS extends SchemaProps = {}
 > = ROOT extends true ? NumberSchema_<PROPS> : NumberSchema<PROPS>
 
+/**
+ * Convert a `zod` number schema to a DDB-TB schema.
+ */
 export const fromZodNumber = (zodSchema: ZodNumber): NumberSchema => withMeta(number(), zodSchema)

--- a/src/schema/actions/fromZodSchema/zodObject.ts
+++ b/src/schema/actions/fromZodSchema/zodObject.ts
@@ -9,8 +9,14 @@ import type { FromZodSchema } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` object schema.
+ */
 export type ZodObjectAny = ZodObject<ZodRawShape, UnknownKeysParam>
 
+/**
+ * DDB-TB schema derived from a `zod` object schema.
+ */
 export type FromZodObject<
   ZOD_SCHEMA extends ZodObjectAny,
   ROOT extends boolean = true,
@@ -28,6 +34,9 @@ export type FromZodObject<
         >
     : never
 
+/**
+ * Convert a `zod` object schema to a DDB-TB schema.
+ */
 export const fromZodObject = (zodObject: ZodObjectAny): MapSchema => {
   const attributes = Object.fromEntries(
     Object.entries(zodObject.shape).map(([key, value]) => [key, fromZodSchema(value)])

--- a/src/schema/actions/fromZodSchema/zodOptional.ts
+++ b/src/schema/actions/fromZodSchema/zodOptional.ts
@@ -8,8 +8,14 @@ import type { FromZodSchema } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` optional schema.
+ */
 export type ZodOptionalAny = ZodOptional<ZodTypeAny>
 
+/**
+ * DDB-TB schema derived from a `zod` optional schema.
+ */
 export type FromZodOptional<
   ZOD_SCHEMA extends ZodOptional<ZodTypeAny>,
   ROOT extends boolean = true,
@@ -19,5 +25,8 @@ export type FromZodOptional<
     ? FromZodSchema<UNWRAPPED_ZOD_SCHEMA, ROOT, Overwrite<PROPS, { required: 'never' }>>
     : never
 
+/**
+ * Convert a `zod` optional schema to a DDB-TB schema.
+ */
 export const fromZodOptional = (zodSchema: ZodOptionalAny): Schema =>
   withMeta(fromZodSchema(zodSchema.unwrap()).optional(), zodSchema)

--- a/src/schema/actions/fromZodSchema/zodRecord.ts
+++ b/src/schema/actions/fromZodSchema/zodRecord.ts
@@ -9,8 +9,14 @@ import type { FromZodSchema } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` record schema.
+ */
 export type ZodRecordAny = ZodRecord<KeySchema>
 
+/**
+ * DDB-TB schema derived from a `zod` record schema.
+ */
 export type FromZodRecord<
   ZOD_SCHEMA extends ZodRecordAny,
   ROOT extends boolean = true,
@@ -32,6 +38,9 @@ export type FromZodRecord<
       : never
     : never
 
+/**
+ * Convert a `zod` record schema to a DDB-TB schema.
+ */
 export const fromZodRecord = (zodRecord: ZodRecordAny): RecordSchema => {
   const { keySchema, valueSchema } = zodRecord
 

--- a/src/schema/actions/fromZodSchema/zodSet.ts
+++ b/src/schema/actions/fromZodSchema/zodSet.ts
@@ -18,6 +18,9 @@ import type { FromZodSchema } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * DDB-TB schema derived from a `zod` set schema.
+ */
 export type FromZodSet<
   ZOD_SCHEMA extends ZodSet,
   ROOT extends boolean = true,
@@ -41,6 +44,9 @@ export type FromZodSet<
             : never)
     : never
 
+/**
+ * Convert a `zod` set schema to a DDB-TB schema.
+ */
 export const fromZodSet = (zodSet: ZodSet): SetSchema => {
   const { valueType } = zodSet._def
 

--- a/src/schema/actions/fromZodSchema/zodString.ts
+++ b/src/schema/actions/fromZodSchema/zodString.ts
@@ -6,9 +6,15 @@ import type { SchemaProps } from '~/schema/types/schemaProps.js'
 
 import { withMeta } from './utils.js'
 
+/**
+ * DDB-TB schema derived from a `zod` string schema.
+ */
 export type FromZodString<
   ROOT extends boolean = true,
   PROPS extends SchemaProps = {}
 > = ROOT extends true ? StringSchema_<PROPS> : StringSchema<PROPS>
 
+/**
+ * Convert a `zod` string schema to a DDB-TB schema.
+ */
 export const fromZodString = (zodSchema: ZodString): StringSchema => withMeta(string(), zodSchema)

--- a/src/schema/actions/fromZodSchema/zodTuple.ts
+++ b/src/schema/actions/fromZodSchema/zodTuple.ts
@@ -8,8 +8,14 @@ import type { FromZodSchemaRec } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` tuple schema.
+ */
 export type ZodTupleAny = ZodTuple<[ZodTypeAny, ...ZodTypeAny[]], ZodTypeAny | null>
 
+/**
+ * DDB-TB schema derived from a `zod` tuple schema.
+ */
 export type FromZodTuple<
   ZOD_SCHEMA extends ZodTupleAny,
   ROOT extends boolean = true,
@@ -21,5 +27,8 @@ export type FromZodTuple<
       : TupleSchema<FromZodSchemaRec<ELEMENT_ZOD_SCHEMAS, false>, PROPS>
     : never
 
+/**
+ * Convert a `zod` tuple schema to a DDB-TB schema.
+ */
 export const fromZodTuple = (zodTuple: ZodTupleAny): TupleSchema =>
   withMeta(tuple(...zodTuple.items.map(item => fromZodSchema(item))), zodTuple)

--- a/src/schema/actions/fromZodSchema/zodUnion.ts
+++ b/src/schema/actions/fromZodSchema/zodUnion.ts
@@ -8,8 +8,14 @@ import type { FromZodSchemaRec } from './fromZodSchema.js'
 import { fromZodSchema } from './fromZodSchema.js'
 import { withMeta } from './utils.js'
 
+/**
+ * Any `zod` union schema.
+ */
 export type ZodUnionAny = ZodUnion<ZodUnionOptions>
 
+/**
+ * DDB-TB schema derived from a `zod` union schema.
+ */
 export type FromZodUnion<
   ZOD_SCHEMA extends ZodUnionAny,
   ROOT extends boolean = true,
@@ -21,5 +27,8 @@ export type FromZodUnion<
       : AnyOfSchema<FromZodSchemaRec<ELEMENT_ZOD_SCHEMAS, false>, PROPS>
     : never
 
+/**
+ * Convert a `zod` union schema to a DDB-TB schema.
+ */
 export const fromZodUnion = (zodUnion: ZodUnionAny): AnyOfSchema =>
   withMeta(anyOf(...zodUnion.options.map(option => fromZodSchema(option))), zodUnion)

--- a/src/schema/actions/jsonSchemer/formattedValue/any.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/any.ts
@@ -3,8 +3,14 @@ import type { AnySchema } from '~/schema/index.js'
 import type { JSONSchemaMeta } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted `any` value.
+ */
 export type FormattedAnyJSONSchema<SCHEMA extends AnySchema> = JSONSchemaMeta<SCHEMA>
 
+/**
+ * Build the JSON Schema of a formatted `any` value.
+ */
 export const getFormattedAnyJSONSchema = <SCHEMA extends AnySchema>(
   schema: SCHEMA
 ): FormattedAnyJSONSchema<SCHEMA> => getJSONSchemaMeta(schema)

--- a/src/schema/actions/jsonSchemer/formattedValue/anyOf.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/anyOf.ts
@@ -6,12 +6,18 @@ import { getFormattedValueJSONSchema } from './schema.js'
 import type { JSONSchemaMeta } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted `anyOf` value.
+ */
 export type FormattedAnyOfJSONSchema<SCHEMA extends AnyOfSchema> = ComputeObject<
   JSONSchemaMeta<SCHEMA> & {
     anyOf: FormattedValueJSONSchemaRec<SCHEMA['elements']>
   }
 >
 
+/**
+ * Build the JSON Schema of a formatted `anyOf` value.
+ */
 export const getFormattedAnyOfJSONSchema = <SCHEMA extends AnyOfSchema>(
   schema: SCHEMA
 ): FormattedAnyOfJSONSchema<SCHEMA> => ({

--- a/src/schema/actions/jsonSchemer/formattedValue/item.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/item.ts
@@ -7,6 +7,9 @@ import { getFormattedValueJSONSchema } from './schema.js'
 import type { JSONSchemaMeta, RequiredProperties } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted `item` value.
+ */
 export type FormattedItemJSONSchema<
   SCHEMA extends ItemSchema,
   REQUIRED_PROPERTIES extends string = RequiredProperties<SCHEMA>
@@ -23,6 +26,9 @@ export type FormattedItemJSONSchema<
     (SCHEMA['props'] extends { strict: true } ? { additionalProperties: false } : {})
 >
 
+/**
+ * Build the JSON Schema of a formatted `item` value.
+ */
 export const getFormattedItemJSONSchema = <SCHEMA extends ItemSchema>(
   schema: SCHEMA
 ): FormattedItemJSONSchema<SCHEMA> => {

--- a/src/schema/actions/jsonSchemer/formattedValue/list.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/list.ts
@@ -6,6 +6,9 @@ import type { FormattedValueJSONSchema } from './schema.js'
 import type { JSONSchemaMeta } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted `list` value.
+ */
 export type FormattedListJSONSchema<SCHEMA extends ListSchema> = ComputeObject<
   JSONSchemaMeta<SCHEMA> & {
     type: 'array'
@@ -13,6 +16,9 @@ export type FormattedListJSONSchema<SCHEMA extends ListSchema> = ComputeObject<
   }
 >
 
+/**
+ * Build the JSON Schema of a formatted `list` value.
+ */
 export const getFormattedListJSONSchema = <SCHEMA extends ListSchema>(
   schema: SCHEMA
 ): FormattedListJSONSchema<SCHEMA> => ({

--- a/src/schema/actions/jsonSchemer/formattedValue/map.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/map.ts
@@ -7,6 +7,9 @@ import { getFormattedValueJSONSchema } from './schema.js'
 import type { JSONSchemaMeta, RequiredProperties } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted `map` value.
+ */
 export type FormattedMapJSONSchema<
   SCHEMA extends MapSchema,
   REQUIRED_PROPERTIES extends string = RequiredProperties<SCHEMA>
@@ -23,6 +26,9 @@ export type FormattedMapJSONSchema<
     (SCHEMA['props'] extends { strict: true } ? { additionalProperties: false } : {})
 >
 
+/**
+ * Build the JSON Schema of a formatted `map` value.
+ */
 export const getFormattedMapJSONSchema = <SCHEMA extends MapSchema>(
   schema: SCHEMA
 ): FormattedMapJSONSchema<SCHEMA> => {

--- a/src/schema/actions/jsonSchemer/formattedValue/primitive.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/primitive.ts
@@ -4,21 +4,25 @@ import type { ComputeObject } from '~/types/computeObject.js'
 import type { JSONSchemaMeta } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted primitive value.
+ */
 export type FormattedPrimitiveJSONSchema<SCHEMA extends PrimitiveSchema> = ComputeObject<
   JSONSchemaMeta<SCHEMA> &
     (SCHEMA extends BinarySchema ? { type: 'string' } : { type: SCHEMA['type'] })
 >
 
+/**
+ * Build the JSON Schema of a formatted primitive value.
+ */
 export const getFormattedPrimitiveJSONSchema = <SCHEMA extends PrimitiveSchema>(
   schema: SCHEMA
 ): FormattedPrimitiveJSONSchema<SCHEMA> => {
-  type Response = FormattedPrimitiveJSONSchema<SCHEMA>
-
   const meta = getJSONSchemaMeta(schema)
 
   if (schema.type === 'binary') {
-    return { ...meta, type: 'string' } as Response
+    return { ...meta, type: 'string' } as FormattedPrimitiveJSONSchema<SCHEMA>
   }
 
-  return { ...meta, type: schema.type } as Response
+  return { ...meta, type: schema.type } as FormattedPrimitiveJSONSchema<SCHEMA>
 }

--- a/src/schema/actions/jsonSchemer/formattedValue/record.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/record.ts
@@ -6,6 +6,9 @@ import { getFormattedValueJSONSchema } from './schema.js'
 import type { JSONSchemaMeta } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted `record` value.
+ */
 export type FormattedRecordJSONSchema<SCHEMA extends RecordSchema> = ComputeObject<
   JSONSchemaMeta<SCHEMA> & {
     type: 'object'
@@ -14,6 +17,9 @@ export type FormattedRecordJSONSchema<SCHEMA extends RecordSchema> = ComputeObje
   }
 >
 
+/**
+ * Build the JSON Schema of a formatted `record` value.
+ */
 export const getFormattedRecordJSONSchema = <SCHEMA extends RecordSchema>(
   schema: SCHEMA
 ): FormattedRecordJSONSchema<SCHEMA> => ({

--- a/src/schema/actions/jsonSchemer/formattedValue/schema.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/schema.ts
@@ -30,37 +30,41 @@ import { getFormattedSetJSONSchema } from './set.js'
 import type { FormattedTupleJSONSchema } from './tuple.js'
 import { getFormattedTupleJSONSchema } from './tuple.js'
 
+/**
+ * Dispatch a schema to the JSON Schema builder of its type.
+ */
 export const getFormattedValueJSONSchema = <SCHEMA extends Schema>(
   schema: SCHEMA
 ): FormattedValueJSONSchema<SCHEMA> => {
-  type RESPONSE = FormattedValueJSONSchema<SCHEMA>
-
   switch (schema.type) {
     case 'any':
-      return getFormattedAnyJSONSchema(schema) as RESPONSE
+      return getFormattedAnyJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
     case 'null':
     case 'boolean':
     case 'number':
     case 'string':
     case 'binary':
-      return getFormattedPrimitiveJSONSchema(schema) as RESPONSE
+      return getFormattedPrimitiveJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
     case 'set':
-      return getFormattedSetJSONSchema(schema) as RESPONSE
+      return getFormattedSetJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
     case 'list':
-      return getFormattedListJSONSchema(schema) as RESPONSE
+      return getFormattedListJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
     case 'tuple':
-      return getFormattedTupleJSONSchema(schema) as RESPONSE
+      return getFormattedTupleJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
     case 'map':
-      return getFormattedMapJSONSchema(schema) as RESPONSE
+      return getFormattedMapJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
     case 'record':
-      return getFormattedRecordJSONSchema(schema) as RESPONSE
+      return getFormattedRecordJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
     case 'anyOf':
-      return getFormattedAnyOfJSONSchema(schema) as RESPONSE
+      return getFormattedAnyOfJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
     case 'item':
-      return getFormattedItemJSONSchema(schema) as RESPONSE
+      return getFormattedItemJSONSchema(schema) as FormattedValueJSONSchema<SCHEMA>
   }
 }
 
+/**
+ * JSON Schema of a formatted value, for any schema type.
+ */
 export type FormattedValueJSONSchema<SCHEMA extends Schema> = Schema extends SCHEMA
   ? Record<string, unknown>
   :
@@ -74,6 +78,9 @@ export type FormattedValueJSONSchema<SCHEMA extends Schema> = Schema extends SCH
       | (SCHEMA extends AnyOfSchema ? FormattedAnyOfJSONSchema<SCHEMA> : never)
       | (SCHEMA extends ItemSchema ? FormattedItemJSONSchema<SCHEMA> : never)
 
+/**
+ * JSON Schemas of a tuple of formatted values, preserving positions.
+ */
 export type FormattedValueJSONSchemaRec<
   SCHEMAS extends Schema[],
   RESULTS extends unknown[] = []

--- a/src/schema/actions/jsonSchemer/formattedValue/set.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/set.ts
@@ -6,6 +6,9 @@ import { getFormattedValueJSONSchema } from './schema.js'
 import type { JSONSchemaMeta } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted `set` value.
+ */
 export type FormattedSetJSONSchema<SCHEMA extends SetSchema> = ComputeObject<
   JSONSchemaMeta<SCHEMA> & {
     type: 'array'
@@ -14,6 +17,9 @@ export type FormattedSetJSONSchema<SCHEMA extends SetSchema> = ComputeObject<
   }
 >
 
+/**
+ * Build the JSON Schema of a formatted `set` value.
+ */
 export const getFormattedSetJSONSchema = <SCHEMA extends SetSchema>(
   schema: SCHEMA
 ): FormattedSetJSONSchema<SCHEMA> => ({

--- a/src/schema/actions/jsonSchemer/formattedValue/tuple.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/tuple.ts
@@ -6,6 +6,9 @@ import { getFormattedValueJSONSchema } from './schema.js'
 import type { JSONSchemaMeta } from './utils.js'
 import { getJSONSchemaMeta } from './utils.js'
 
+/**
+ * JSON Schema of a formatted `tuple` value.
+ */
 export type FormattedTupleJSONSchema<SCHEMA extends TupleSchema> = ComputeObject<
   JSONSchemaMeta<SCHEMA> & {
     type: 'array'
@@ -15,6 +18,9 @@ export type FormattedTupleJSONSchema<SCHEMA extends TupleSchema> = ComputeObject
   }
 >
 
+/**
+ * Build the JSON Schema of a formatted `tuple` value.
+ */
 export const getFormattedTupleJSONSchema = <SCHEMA extends TupleSchema>(
   schema: SCHEMA
 ): FormattedTupleJSONSchema<SCHEMA> => ({

--- a/src/schema/actions/jsonSchemer/formattedValue/utils.ts
+++ b/src/schema/actions/jsonSchemer/formattedValue/utils.ts
@@ -1,6 +1,9 @@
 import type { ItemSchema, MapSchema, Never, Schema } from '~/schema/index.js'
 import type { OmitKeys } from '~/types/omitKeys.js'
 
+/**
+ * Names of the non-hidden, non-optional properties of a `map` or `item`.
+ */
 export type RequiredProperties<SCHEMA extends MapSchema | ItemSchema> = ItemSchema extends SCHEMA
   ? string
   : MapSchema extends SCHEMA
@@ -12,12 +15,18 @@ export type RequiredProperties<SCHEMA extends MapSchema | ItemSchema> = ItemSche
         >]: SCHEMA['attributes'][KEY]['props'] extends { required: Never } ? never : KEY
       }[OmitKeys<SCHEMA['attributes'], { props: { hidden: true } }>]
 
+/**
+ * JSON Schema metadata (title, description, examples) carried by a schema.
+ */
 export type JSONSchemaMeta<SCHEMA extends Schema> = SCHEMA extends { props: { meta: infer META } }
   ? (META extends { title: infer TITLE } ? { title: TITLE } : unknown) &
       (META extends { description: infer DESCRIPTION } ? { description: DESCRIPTION } : unknown) &
       (META extends { examples: infer EXAMPLES } ? { examples: EXAMPLES } : unknown)
   : {}
 
+/**
+ * Extract a schema's JSON Schema metadata into a plain object.
+ */
 export const getJSONSchemaMeta = <SCHEMA extends Schema>({
   props: { meta }
 }: SCHEMA): JSONSchemaMeta<SCHEMA> => {

--- a/src/schema/actions/jsonSchemer/jsonSchemer.ts
+++ b/src/schema/actions/jsonSchemer/jsonSchemer.ts
@@ -4,9 +4,15 @@ import { SchemaAction } from '~/schema/index.js'
 import { getFormattedValueJSONSchema } from './formattedValue/index.js'
 import type { FormattedValueJSONSchema } from './formattedValue/index.js'
 
+/**
+ * Convert a schema to the JSON Schema of its formatted value.
+ */
 export class JSONSchemer<SCHEMA extends Schema = Schema> extends SchemaAction<SCHEMA> {
   static override actionName = 'jsonSchemer' as const
 
+  /**
+   * Build the JSON Schema of the schema's formatted value.
+   */
   formattedValueSchema(): FormattedValueJSONSchema<SCHEMA> {
     return getFormattedValueJSONSchema(this.schema)
   }

--- a/src/schema/actions/parse/any.ts
+++ b/src/schema/actions/parse/any.ts
@@ -5,6 +5,9 @@ import type { ParseAttrValueOptions } from './options.js'
 import type { ParserReturn, ParserYield } from './parser.js'
 import { applyCustomValidation } from './utils.js'
 
+/**
+ * Parse a value against an `any` schema.
+ */
 export function* anySchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: AnySchema,
   inputValue: unknown,

--- a/src/schema/actions/parse/anyOf.ts
+++ b/src/schema/actions/parse/anyOf.ts
@@ -10,6 +10,9 @@ import type { ParserReturn, ParserYield } from './parser.js'
 import { schemaParser } from './schema.js'
 import { applyCustomValidation } from './utils.js'
 
+/**
+ * Parse a value against an `anyOf` schema.
+ */
 export function* anyOfSchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: AnyOfSchema,
   inputValue: unknown,

--- a/src/schema/actions/parse/errors.ts
+++ b/src/schema/actions/parse/errors.ts
@@ -41,6 +41,9 @@ type AdditionalPropertyErrorBlueprint = ErrorBlueprint<{
   }
 }>
 
+/**
+ * Union of the error blueprints raised while parsing a value.
+ */
 export type ParserErrorBlueprints =
   | InvalidItemErrorBlueprint
   | AttributeRequiredErrorBlueprint

--- a/src/schema/actions/parse/item.ts
+++ b/src/schema/actions/parse/item.ts
@@ -7,6 +7,9 @@ import type { ParseValueOptions } from './options.js'
 import type { ParserReturn, ParserYield } from './parser.js'
 import { schemaParser } from './schema.js'
 
+/**
+ * Parse a value against an `item` schema.
+ */
 export function* itemParser<SCHEMA extends ItemSchema, OPTIONS extends ParseValueOptions = {}>(
   schema: SCHEMA,
   inputValue: unknown,

--- a/src/schema/actions/parse/list.ts
+++ b/src/schema/actions/parse/list.ts
@@ -9,6 +9,9 @@ import type { ParserReturn, ParserYield } from './parser.js'
 import { schemaParser } from './schema.js'
 import { applyCustomValidation } from './utils.js'
 
+/**
+ * Parse a value against a `list` schema.
+ */
 export function* listSchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: ListSchema,
   inputValue: unknown,

--- a/src/schema/actions/parse/map.ts
+++ b/src/schema/actions/parse/map.ts
@@ -9,6 +9,9 @@ import type { ParserReturn, ParserYield } from './parser.js'
 import { schemaParser } from './schema.js'
 import { applyCustomValidation } from './utils.js'
 
+/**
+ * Parse a value against a `map` schema.
+ */
 export function* mapSchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: MapSchema,
   inputValue: unknown,

--- a/src/schema/actions/parse/options.ts
+++ b/src/schema/actions/parse/options.ts
@@ -1,6 +1,9 @@
 import type { ArrayPath } from '~/schema/actions/utils/types.js'
 import type { $contextExtension, $extension, ExtensionParser, WriteMode } from '~/schema/index.js'
 
+/**
+ * Options accepted by the parser.
+ */
 export interface ParseValueOptions {
   mode?: WriteMode
   fill?: boolean
@@ -9,10 +12,16 @@ export interface ParseValueOptions {
   parseExtension?: ExtensionParser
 }
 
+/**
+ * Parser options extended with the value's array path.
+ */
 export interface ParseAttrValueOptions extends ParseValueOptions {
   valuePath?: ArrayPath
 }
 
+/**
+ * Derives write value options from parser options.
+ */
 export interface InferWriteValueOptions<
   OPTIONS extends ParseValueOptions,
   USE_CONTEXT_EXTENSION extends boolean = false

--- a/src/schema/actions/parse/parser.ts
+++ b/src/schema/actions/parse/parser.ts
@@ -20,6 +20,9 @@ type ParserInput<
   ? ValidValue<SCHEMA, WRITE_VALUE_OPTIONS>
   : InputValue<SCHEMA, WRITE_VALUE_OPTIONS>
 
+/**
+ * Values yielded by the parser at each pipeline step.
+ */
 export type ParserYield<
   SCHEMA extends Schema,
   OPTIONS extends ParseValueOptions = {},
@@ -28,6 +31,9 @@ export type ParserYield<
   | (OPTIONS extends { fill: false } ? never : InputValue<SCHEMA, WRITE_VALUE_OPTIONS>)
   | ValidValue<SCHEMA, WRITE_VALUE_OPTIONS>
 
+/**
+ * Final value returned by the parser.
+ */
 export type ParserReturn<
   SCHEMA extends Schema,
   OPTIONS extends ParseValueOptions = {},
@@ -36,9 +42,15 @@ export type ParserReturn<
   ? ValidValue<SCHEMA, WRITE_VALUE_OPTIONS>
   : TransformedValue<SCHEMA, WRITE_VALUE_OPTIONS>
 
+/**
+ * Validates and transforms an input value toward its saved form.
+ */
 export class Parser<SCHEMA extends Schema> extends SchemaAction<SCHEMA> {
   static override actionName = 'parse' as const
 
+  /**
+   * Run the parse pipeline lazily, yielding each intermediate step.
+   */
   start<OPTIONS extends ParseValueOptions = {}>(
     inputValue: unknown,
     options: OPTIONS = {} as OPTIONS
@@ -56,6 +68,9 @@ export class Parser<SCHEMA extends Schema> extends SchemaAction<SCHEMA> {
     }
   }
 
+  /**
+   * Parse an input value into its transformed (saved) form.
+   */
   parse<OPTIONS extends ParseValueOptions = {}>(
     inputValue: unknown,
     options: OPTIONS = {} as OPTIONS
@@ -74,6 +89,9 @@ export class Parser<SCHEMA extends Schema> extends SchemaAction<SCHEMA> {
     return value
   }
 
+  /**
+   * Parse an already-typed input value.
+   */
   reparse<OPTIONS extends ParseValueOptions = {}>(
     inputValue: ParserInput<SCHEMA, OPTIONS>,
     options: OPTIONS = {} as OPTIONS
@@ -81,6 +99,9 @@ export class Parser<SCHEMA extends Schema> extends SchemaAction<SCHEMA> {
     return this.parse(inputValue, options)
   }
 
+  /**
+   * Whether an input value is valid against the schema.
+   */
   validate<OPTIONS extends Omit<ParseValueOptions, 'fill' | 'transform'> = {}>(
     inputValue: unknown,
     options: OPTIONS = {} as OPTIONS

--- a/src/schema/actions/parse/primitive.ts
+++ b/src/schema/actions/parse/primitive.ts
@@ -9,6 +9,9 @@ import type { ParseAttrValueOptions } from './options.js'
 import type { ParserReturn, ParserYield } from './parser.js'
 import { applyCustomValidation } from './utils.js'
 
+/**
+ * Parse a value against a primitive schema.
+ */
 export function* primitiveSchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: PrimitiveSchema,
   inputValue: unknown,

--- a/src/schema/actions/parse/record.ts
+++ b/src/schema/actions/parse/record.ts
@@ -9,6 +9,9 @@ import type { ParserReturn, ParserYield } from './parser.js'
 import { schemaParser } from './schema.js'
 import { applyCustomValidation } from './utils.js'
 
+/**
+ * Parse a value against a record schema.
+ */
 export function* recordSchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: RecordSchema,
   inputValue: unknown,

--- a/src/schema/actions/parse/schema.ts
+++ b/src/schema/actions/parse/schema.ts
@@ -16,6 +16,9 @@ import { setSchemaParser } from './set.js'
 import { tupleSchemaParser } from './tuple.js'
 import { defaultParseExtension, isRequired } from './utils.js'
 
+/**
+ * Parse a value against any non-item schema.
+ */
 export function* schemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: Schema,
   inputValue: unknown,

--- a/src/schema/actions/parse/set.ts
+++ b/src/schema/actions/parse/set.ts
@@ -9,6 +9,9 @@ import type { ParserReturn, ParserYield } from './parser.js'
 import { schemaParser } from './schema.js'
 import { applyCustomValidation } from './utils.js'
 
+/**
+ * Parse a value against a `set` schema.
+ */
 export function* setSchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: SetSchema,
   inputValue: unknown,

--- a/src/schema/actions/parse/tuple.ts
+++ b/src/schema/actions/parse/tuple.ts
@@ -9,6 +9,9 @@ import type { ParserReturn, ParserYield } from './parser.js'
 import { schemaParser } from './schema.js'
 import { applyCustomValidation } from './utils.js'
 
+/**
+ * Parse a value against a `tuple` schema.
+ */
 export function* tupleSchemaParser<OPTIONS extends ParseAttrValueOptions = {}>(
   schema: TupleSchema,
   inputValue: unknown,

--- a/src/schema/actions/parse/utils.ts
+++ b/src/schema/actions/parse/utils.ts
@@ -5,11 +5,17 @@ import { isString } from '~/utils/validation/isString.js'
 
 import type { ParseAttrValueOptions } from './options.js'
 
+/**
+ * Extension parser that treats every value as unextended.
+ */
 export const defaultParseExtension: ExtensionParser<never> = (_, input) => ({
   isExtension: false,
   unextendedInput: input as SchemaUnextendedValue<never> | undefined
 })
 
+/**
+ * Whether a schema must be provided in a given write mode.
+ */
 export const isRequired = (schema: Schema, mode: WriteMode): boolean => {
   switch (mode) {
     case 'put':
@@ -35,6 +41,9 @@ const getValidator = (schema: Schema, mode: WriteMode) => {
   }
 }
 
+/**
+ * Run a schema's custom validator and throw on failure.
+ */
 export const applyCustomValidation = (
   schema: Schema,
   inputValue: unknown,

--- a/src/schema/actions/parseCondition/condition.ts
+++ b/src/schema/actions/parseCondition/condition.ts
@@ -29,6 +29,9 @@ import type {
 } from '~/schema/index.js'
 import type { Extends, If } from '~/types/index.js'
 
+/**
+ * Conditions available on an `any` attribute.
+ */
 export type AnySchemaCondition<
   SCHEMA extends AnySchema,
   ATTR_PATH extends string,
@@ -37,8 +40,14 @@ export type AnySchemaCondition<
   | AttrCondition<ATTR_PATH, Exclude<Schema, AnySchema>, ALL_PATHS, ResolveAnySchema<SCHEMA>>
   | AttrCondition<`${ATTR_PATH}${string}`, Exclude<Schema, AnySchema>, ALL_PATHS>
 
+/**
+ * DynamoDB attribute type codes usable in a `type` condition.
+ */
 export type ConditionType = 'S' | 'SS' | 'N' | 'NS' | 'B' | 'BS' | 'BOOL' | 'NULL' | 'L' | 'M'
 
+/**
+ * Condition on a single attribute, dispatched by its schema type.
+ */
 export type AttrCondition<
   ATTR_PATH extends string,
   SCHEMA extends Schema,
@@ -66,16 +75,25 @@ export type AttrCondition<
   | (SCHEMA extends RecordSchema ? RecordSchemaCondition<ATTR_PATH, SCHEMA, ALL_PATHS> : never)
   | (SCHEMA extends AnyOfSchema ? AnyOfSchemaCondition<ATTR_PATH, SCHEMA, ALL_PATHS> : never)
 
+/**
+ * Condition asserting an attribute exists or not.
+ */
 export type ExistsCondition<ATTR_PATH extends string> = {
   attr: ATTR_PATH
   exists: boolean
 }
 
+/**
+ * Condition asserting an attribute's DynamoDB type.
+ */
 export type TypeCondition<ATTR_PATH extends string> = {
   attr: ATTR_PATH
   type: ConditionType
 }
 
+/**
+ * Condition asserting an attribute equals a value.
+ */
 export type EqCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -92,6 +110,9 @@ type SizeEqCondition<ATTR_PATH extends string, ALL_PATHS extends string> = {
   eq: number | { attr: ALL_PATHS }
 }
 
+/**
+ * Condition asserting an attribute differs from a value.
+ */
 export type NotEqCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -108,6 +129,9 @@ type SizeNotEqCondition<ATTR_PATH extends string, ALL_PATHS extends string> = {
   ne: number | { attr: ALL_PATHS }
 }
 
+/**
+ * Condition asserting an attribute is one of several values.
+ */
 export type InCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -124,6 +148,9 @@ type SizeInCondition<ATTR_PATH extends string, ALL_PATHS extends string> = {
   in: (number | { attr: ALL_PATHS })[]
 }
 
+/**
+ * Equality conditions (`eq`, `ne`, `in`) on an attribute.
+ */
 export type ValueCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -139,6 +166,9 @@ type SizeValueCondition<ATTR_PATH extends string, ALL_PATHS extends string> =
   | SizeNotEqCondition<ATTR_PATH, ALL_PATHS>
   | SizeInCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Condition asserting an attribute is less than a value.
+ */
 export type LessThanCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -155,6 +185,9 @@ type SizeLessThanCondition<ATTR_PATH extends string, ALL_PATHS extends string> =
   lt: number | { attr: ALL_PATHS }
 }
 
+/**
+ * Condition asserting an attribute is less than or equal to a value.
+ */
 export type LessThanOrEqCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -171,6 +204,9 @@ type SizeLessThanOrEqCondition<ATTR_PATH extends string, ALL_PATHS extends strin
   lte: number | { attr: ALL_PATHS }
 }
 
+/**
+ * Condition asserting an attribute is greater than a value.
+ */
 export type GreaterThanCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -187,6 +223,9 @@ type SizeGreaterThanCondition<ATTR_PATH extends string, ALL_PATHS extends string
   gt: number | { attr: ALL_PATHS }
 }
 
+/**
+ * Condition asserting an attribute is greater than or equal to a value.
+ */
 export type GreaterThanOrEqCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -203,6 +242,9 @@ type SizeGreaterThanOrEqCondition<ATTR_PATH extends string, ALL_PATHS extends st
   gte: number | { attr: ALL_PATHS }
 }
 
+/**
+ * Condition asserting an attribute is within a range.
+ */
 export type BetweenCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -222,6 +264,9 @@ type SizeBetweenCondition<ATTR_PATH extends string, ALL_PATHS extends string> = 
   between: [number | { attr: ALL_PATHS }, number | { attr: ALL_PATHS }]
 }
 
+/**
+ * Ordering conditions (`lt`, `lte`, `gt`, `gte`, `between`) on an attribute.
+ */
 export type RangeCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -241,14 +286,23 @@ type SizeRangeCondition<ATTR_PATH extends string, ALL_PATHS extends string> =
   | SizeGreaterThanOrEqCondition<ATTR_PATH, ALL_PATHS>
   | SizeBetweenCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Condition on the size of an attribute.
+ */
 export type SizeCondition<ATTR_PATH extends string, ALL_PATHS extends string> =
   | SizeValueCondition<ATTR_PATH, ALL_PATHS>
   | SizeRangeCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Conditions available on a `null` attribute.
+ */
 export type NullSchemaCondition<ATTR_PATH extends string> =
   | ExistsCondition<ATTR_PATH>
   | TypeCondition<ATTR_PATH>
 
+/**
+ * Conditions available on a `boolean` attribute.
+ */
 export type BooleanSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends BooleanSchema,
@@ -259,6 +313,9 @@ export type BooleanSchemaCondition<
   | TypeCondition<ATTR_PATH>
   | ValueCondition<ATTR_PATH, ResolveBooleanSchema<SCHEMA>, ALL_PATHS, CUSTOM_VALUE>
 
+/**
+ * Conditions available on a `number` attribute.
+ */
 export type NumberSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends NumberSchema,
@@ -270,6 +327,9 @@ export type NumberSchemaCondition<
   | ValueCondition<ATTR_PATH, ResolveNumberSchema<SCHEMA>, ALL_PATHS, CUSTOM_VALUE>
   | RangeCondition<ATTR_PATH, ResolvedNumberSchema, ALL_PATHS, CUSTOM_VALUE>
 
+/**
+ * Condition asserting an attribute contains a value.
+ */
 export type ContainsCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -281,6 +341,9 @@ export type ContainsCondition<
   transform?: boolean
 }
 
+/**
+ * Condition asserting a string attribute begins with a value.
+ */
 export type BeginsWithCondition<
   ATTR_PATH extends string,
   ATTR_VALUE,
@@ -292,6 +355,9 @@ export type BeginsWithCondition<
   transform?: boolean
 }
 
+/**
+ * Conditions available on a `string` attribute.
+ */
 export type StringSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends StringSchema,
@@ -307,6 +373,9 @@ export type StringSchemaCondition<
   // "If the attribute is of type `String`, `size` returns the length of the string"
   | SizeCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Conditions available on a `binary` attribute.
+ */
 export type BinarySchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends BinarySchema,
@@ -320,6 +389,9 @@ export type BinarySchemaCondition<
   // "If the attribute is of type `Binary`, `size` returns the number of bytes in the attribute value"
   | SizeCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Conditions available on a `set` attribute.
+ */
 export type SetSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends SetSchema,
@@ -331,6 +403,9 @@ export type SetSchemaCondition<
   // "If the attribute is a `Set` data type, `size` returns the number of elements in the set"
   | SizeCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Conditions available on a `list` attribute.
+ */
 export type ListSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends ListSchema,
@@ -348,6 +423,9 @@ export type ListSchemaCondition<
   // "If the attribute is of type `List` or `Map`, `size` returns the number of child elements.""
   | SizeCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Conditions available on a `tuple` attribute.
+ */
 export type TupleSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends TupleSchema,
@@ -386,6 +464,9 @@ type TupleSchemaConditionRec<
     : never
   : RESULTS
 
+/**
+ * Conditions available on a `map` attribute.
+ */
 export type MapSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends MapSchema,
@@ -406,6 +487,9 @@ export type MapSchemaCondition<
   // "If the attribute is of type `List` or `Map`, `size` returns the number of child elements.""
   | SizeCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Conditions available on a `record` attribute.
+ */
 export type RecordSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends RecordSchema,
@@ -424,6 +508,9 @@ export type RecordSchemaCondition<
   // "If the attribute is of type `List` or `Map`, `size` returns the number of child elements.""
   | SizeCondition<ATTR_PATH, ALL_PATHS>
 
+/**
+ * Conditions available on an `anyOf` attribute.
+ */
 export type AnyOfSchemaCondition<
   ATTR_PATH extends string,
   SCHEMA extends AnyOfSchema,
@@ -440,6 +527,9 @@ export type AnyOfSchemaCondition<
           : never
         : never)
 
+/**
+ * Any condition on a single attribute (no `and`/`or`/`not`).
+ */
 export type NonLogicalCondition<SCHEMA extends ItemSchema = ItemSchema> = ItemSchema extends SCHEMA
   ? FreeCondition | AnySchemaCondition<AnySchema, string, string>
   :
@@ -531,11 +621,17 @@ type FreeContainsCondition<VALUE extends ContainersAttributes = ContainersAttrib
       }
     : never
 
+/**
+ * A combination of conditions via `and`, `or` or `not`.
+ */
 export type LogicalCondition<SCHEMA extends ItemSchema = ItemSchema> =
   | { and: SchemaCondition<SCHEMA>[] }
   | { or: SchemaCondition<SCHEMA>[] }
   | { not: SchemaCondition<SCHEMA> }
 
+/**
+ * A type-safe condition over a schema's attributes.
+ */
 export type SchemaCondition<SCHEMA extends ItemSchema = ItemSchema> =
   | LogicalCondition<SCHEMA>
   | NonLogicalCondition<SCHEMA>

--- a/src/schema/actions/parseCondition/conditionParser.ts
+++ b/src/schema/actions/parseCondition/conditionParser.ts
@@ -6,20 +6,36 @@ import { expressCondition } from './expressCondition/expressCondition.js'
 import { transformCondition } from './transformCondition/index.js'
 import type { ConditionExpression } from './types.js'
 
+/**
+ * Options accepted by the condition parser.
+ */
 export interface ParseConditionOptions {
   expressionId?: string
 }
 
+/**
+ * Compiles a condition into a DynamoDB condition expression.
+ */
 export class ConditionParser<SCHEMA extends Schema = Schema> extends SchemaAction<SCHEMA> {
   static override actionName = 'parseCondition' as const
+
+  /**
+   * Render a transformed condition into a condition expression.
+   */
   static express(condition: SchemaCondition, expressionId = ''): ConditionExpression {
     return expressCondition(condition, expressionId)
   }
 
+  /**
+   * Apply schema transformers to a condition's operands.
+   */
   transform(condition: SchemaCondition): SchemaCondition {
     return transformCondition(this.schema, condition)
   }
 
+  /**
+   * Compile a condition into a condition expression.
+   */
   parse(
     condition: SchemaCondition,
     { expressionId }: ParseConditionOptions = {}

--- a/src/schema/actions/parseCondition/expressCondition/conditions/beginsWith.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/beginsWith.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import type { ExpressionState } from '../types.js'
 import { attrOrValueTokens, pathTokens, valueToken } from './utils.js'
 
+/**
+ * Render a `beginsWith` condition.
+ */
 export const expressBeginsWithCondition = (
   condition: Extract<SchemaCondition, { beginsWith: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/between.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/between.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import type { ExpressionState } from '../types.js'
 import { attrOrValueTokens, pathTokens, valueToken } from './utils.js'
 
+/**
+ * Render a `between` condition.
+ */
 export const expressBetweenCondition = (
   condition: Extract<SchemaCondition, { between: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/contains.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/contains.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import type { ExpressionState } from '../types.js'
 import { attrOrValueTokens, pathTokens, valueToken } from './utils.js'
 
+/**
+ * Render a `contains` condition.
+ */
 export const expressContainsCondition = (
   condition: Extract<SchemaCondition, { contains: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/eq.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/eq.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import type { ExpressionState } from '../types.js'
 import { attrOrValueTokens, pathTokens, valueToken } from './utils.js'
 
+/**
+ * Render an `eq` condition.
+ */
 export const expressEqCondition = (
   condition: Extract<SchemaCondition, { eq: unknown }>,
   prefix = '',
@@ -27,6 +30,9 @@ export const expressEqCondition = (
   }
 }
 
+/**
+ * Render a `ne` condition.
+ */
 export const expressNeCondition = (
   condition: Extract<SchemaCondition, { ne: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/exists.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/exists.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import type { ExpressionState } from '../types.js'
 import { pathTokens } from './utils.js'
 
+/**
+ * Render an `exists` condition.
+ */
 export const expressExistsCondition = (
   condition: Extract<SchemaCondition, { exists: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/in.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/in.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import type { ExpressionState } from '../types.js'
 import { attrOrValueTokens, pathTokens, valueToken } from './utils.js'
 
+/**
+ * Render an `in` condition.
+ */
 export const expressInCondition = (
   condition: Extract<SchemaCondition, { in: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/logical.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/logical.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import { expressCondition } from '../expressCondition.js'
 import type { ExpressionState } from '../types.js'
 
+/**
+ * Render an `or` condition.
+ */
 export const expressOrCondition = (
   condition: Extract<SchemaCondition, { or: unknown }>,
   prefix = '',
@@ -30,6 +33,9 @@ export const expressOrCondition = (
   }
 }
 
+/**
+ * Render an `and` condition.
+ */
 export const expressAndCondition = (
   condition: Extract<SchemaCondition, { and: unknown }>,
   prefix = '',
@@ -57,6 +63,9 @@ export const expressAndCondition = (
   }
 }
 
+/**
+ * Render a `not` condition.
+ */
 export const expressNotCondition = (
   condition: Extract<SchemaCondition, { not: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/range.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/range.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import type { ExpressionState } from '../types.js'
 import { attrOrValueTokens, pathTokens, valueToken } from './utils.js'
 
+/**
+ * Render a `gte` condition.
+ */
 export const expressGteCondition = (
   condition: Extract<SchemaCondition, { gte: unknown }>,
   prefix = '',
@@ -27,6 +30,9 @@ export const expressGteCondition = (
   }
 }
 
+/**
+ * Render a `gt` condition.
+ */
 export const expressGtCondition = (
   condition: Extract<SchemaCondition, { gt: unknown }>,
   prefix = '',
@@ -51,6 +57,9 @@ export const expressGtCondition = (
   }
 }
 
+/**
+ * Render a `lte` condition.
+ */
 export const expressLteCondition = (
   condition: Extract<SchemaCondition, { lte: unknown }>,
   prefix = '',
@@ -75,6 +84,9 @@ export const expressLteCondition = (
   }
 }
 
+/**
+ * Render a `lt` condition.
+ */
 export const expressLtCondition = (
   condition: Extract<SchemaCondition, { lt: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/type.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/type.ts
@@ -3,6 +3,9 @@ import type { ConditionExpression } from '../../types.js'
 import type { ExpressionState } from '../types.js'
 import { pathTokens, valueToken } from './utils.js'
 
+/**
+ * Render a `type` condition.
+ */
 export const expressTypeCondition = (
   condition: Extract<SchemaCondition, { type: unknown }>,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/conditions/utils.ts
+++ b/src/schema/actions/parseCondition/expressCondition/conditions/utils.ts
@@ -4,6 +4,9 @@ import { isObject } from '~/utils/validation/isObject.js'
 
 import type { ExpressionState } from '../types.js'
 
+/**
+ * Render an attribute path into expression tokens.
+ */
 export const pathTokens = (
   attr: string,
   prefix = '',
@@ -41,6 +44,9 @@ export const pathTokens = (
   return tokens
 }
 
+/**
+ * Register a value and return its expression token.
+ */
 export const valueToken = (value: unknown, prefix = '', state: ExpressionState): string => {
   const token = `:c${prefix}_${state.valuesCursor}`
   state.ExpressionAttributeValues[token] = value
@@ -55,6 +61,9 @@ export const valueToken = (value: unknown, prefix = '', state: ExpressionState):
 const isAttr = (attrOrValue: unknown): attrOrValue is { attr: string } =>
   isObject(attrOrValue) && 'attr' in attrOrValue
 
+/**
+ * Render an attribute reference or a literal value into tokens.
+ */
 export const attrOrValueTokens = (
   attrOrValue: unknown,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/expressCondition.ts
+++ b/src/schema/actions/parseCondition/expressCondition/expressCondition.ts
@@ -22,6 +22,9 @@ import {
 import { expressTypeCondition } from './conditions/type.js'
 import type { ExpressionState } from './types.js'
 
+/**
+ * Render a condition into a DynamoDB condition expression.
+ */
 export const expressCondition = (
   condition: SchemaCondition,
   prefix = '',

--- a/src/schema/actions/parseCondition/expressCondition/types.ts
+++ b/src/schema/actions/parseCondition/expressCondition/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Mutable state threaded through condition expression building.
+ */
 export interface ExpressionState {
   namesCursor: number
   valuesCursor: number

--- a/src/schema/actions/parseCondition/transformCondition/conditions/beginsWith.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/beginsWith.ts
@@ -6,6 +6,9 @@ import { Parser } from '../../../parse/parser.js'
 import type { SchemaCondition } from '../../condition.js'
 import { getComparedSubSchemas, joinDedupedConditions } from './utils.js'
 
+/**
+ * Transform the operand of a `beginsWith` condition.
+ */
 export const transformBeginsWithCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { beginsWith: unknown; value?: never }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/between.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/between.ts
@@ -7,6 +7,9 @@ import { Parser } from '../../../parse/parser.js'
 import type { SchemaCondition } from '../../condition.js'
 import { getComparedSubSchemas, joinDedupedConditions } from './utils.js'
 
+/**
+ * Transform the operands of a `between` condition.
+ */
 export const transformBetweenCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { between: unknown; value?: never }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/contains.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/contains.ts
@@ -7,6 +7,9 @@ import { Parser } from '../../../parse/parser.js'
 import type { SchemaCondition } from '../../condition.js'
 import { getComparedSubSchemas, joinDedupedConditions } from './utils.js'
 
+/**
+ * Transform the operand of a `contains` condition.
+ */
 export const transformContainsCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { contains: unknown; value?: never }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/eq.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/eq.ts
@@ -7,6 +7,9 @@ import { Parser } from '../../../parse/parser.js'
 import type { SchemaCondition } from '../../condition.js'
 import { getComparedSubSchemas, joinDedupedConditions } from './utils.js'
 
+/**
+ * Transform the operand of an `eq` condition.
+ */
 export const transformEqCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { eq: unknown; value?: never }>
@@ -44,6 +47,9 @@ export const transformEqCondition = (
   return joinDedupedConditions(conditions, attributePath)
 }
 
+/**
+ * Transform the operand of a `ne` condition.
+ */
 export const transformNeCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { ne: unknown; value?: never }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/exists.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/exists.ts
@@ -5,6 +5,9 @@ import type { Schema } from '~/schema/index.js'
 import type { SchemaCondition } from '../../condition.js'
 import { joinDedupedConditions } from './utils.js'
 
+/**
+ * Transform an `exists` condition to its saved attribute paths.
+ */
 export const transformExistsCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { exists: unknown }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/in.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/in.ts
@@ -7,6 +7,9 @@ import { Parser } from '../../../parse/parser.js'
 import type { SchemaCondition } from '../../condition.js'
 import { getComparedSubSchemas, joinDedupedConditions } from './utils.js'
 
+/**
+ * Transform the operands of an `in` condition.
+ */
 export const transformInCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { in: unknown; value?: never }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/logical.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/logical.ts
@@ -3,16 +3,25 @@ import type { Schema } from '~/schema/index.js'
 import type { SchemaCondition } from '../../condition.js'
 import { transformCondition } from '../transformCondition.js'
 
+/**
+ * Transform the operands of an `or` condition.
+ */
 export const transformOrCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { or: unknown }>
 ): SchemaCondition => ({ or: condition.or.map(cond => transformCondition(schema, cond)) })
 
+/**
+ * Transform the operands of an `and` condition.
+ */
 export const transformAndCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { and: unknown }>
 ): SchemaCondition => ({ and: condition.and.map(cond => transformCondition(schema, cond)) })
 
+/**
+ * Transform the operand of a `not` condition.
+ */
 export const transformNotCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { not: unknown }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/range.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/range.ts
@@ -7,6 +7,9 @@ import { Parser } from '../../../parse/parser.js'
 import type { SchemaCondition } from '../../condition.js'
 import { getComparedSubSchemas, joinDedupedConditions } from './utils.js'
 
+/**
+ * Transform the operand of a `gte` condition.
+ */
 export const transformGteCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { gte: unknown; value?: never }>
@@ -44,6 +47,9 @@ export const transformGteCondition = (
   return joinDedupedConditions(conditions, attributePath)
 }
 
+/**
+ * Transform the operand of a `gt` condition.
+ */
 export const transformGtCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { gt: unknown; value?: never }>
@@ -81,6 +87,9 @@ export const transformGtCondition = (
   return joinDedupedConditions(conditions, attributePath)
 }
 
+/**
+ * Transform the operand of a `lte` condition.
+ */
 export const transformLteCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { lte: unknown; value?: never }>
@@ -118,6 +127,9 @@ export const transformLteCondition = (
   return joinDedupedConditions(conditions, attributePath)
 }
 
+/**
+ * Transform the operand of a `lt` condition.
+ */
 export const transformLtCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { lt: unknown; value?: never }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/type.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/type.ts
@@ -12,6 +12,9 @@ const typeSchema = new StringSchema({
 })
 const typeParser = new Parser(typeSchema)
 
+/**
+ * Transform a `type` condition to its saved attribute paths.
+ */
 export const transformTypeCondition = (
   schema: Schema,
   condition: Extract<SchemaCondition, { type: unknown; value?: never }>

--- a/src/schema/actions/parseCondition/transformCondition/conditions/utils.ts
+++ b/src/schema/actions/parseCondition/transformCondition/conditions/utils.ts
@@ -6,6 +6,9 @@ import { isString } from '~/utils/validation/isString.js'
 
 import type { SchemaCondition } from '../../condition.js'
 
+/**
+ * Resolve the sub-schemas referenced by a comparison operand.
+ */
 export const getComparedSubSchemas = (
   schemaFinder: Finder,
   comparedValue: unknown,
@@ -21,6 +24,9 @@ export const getComparedSubSchemas = (
     ? schemaFinder.search(comparedValue.attr)
     : undefined
 
+/**
+ * Combine deduplicated conditions into a single `or` condition.
+ */
 export const joinDedupedConditions = (
   dedupedConditions: Deduper<SchemaCondition>,
   attributePath: string

--- a/src/schema/actions/parseCondition/transformCondition/errors.ts
+++ b/src/schema/actions/parseCondition/transformCondition/errors.ts
@@ -6,4 +6,7 @@ type InvalidConditionErrorBlueprint = ErrorBlueprint<{
   payload: undefined
 }>
 
+/**
+ * Error blueprint raised while transforming a condition.
+ */
 export type TransformConditionErrorBlueprints = InvalidConditionErrorBlueprint

--- a/src/schema/actions/parseCondition/transformCondition/transformCondition.ts
+++ b/src/schema/actions/parseCondition/transformCondition/transformCondition.ts
@@ -21,6 +21,9 @@ import {
 } from './conditions/range.js'
 import { transformTypeCondition } from './conditions/type.js'
 
+/**
+ * Apply schema transformers to a condition's operands.
+ */
 export const transformCondition = (schema: Schema, condition: SchemaCondition): SchemaCondition => {
   if ('value' in condition) {
     return condition

--- a/src/schema/actions/parseCondition/types.ts
+++ b/src/schema/actions/parseCondition/types.ts
@@ -1,3 +1,6 @@
+/**
+ * A DynamoDB condition expression and its attribute name/value maps.
+ */
 export interface ConditionExpression {
   ConditionExpression: string
   ExpressionAttributeNames: Record<string, string>

--- a/src/schema/actions/parsePaths/expressPaths.ts
+++ b/src/schema/actions/parsePaths/expressPaths.ts
@@ -3,6 +3,9 @@ import { isNumber } from '~/utils/validation/isNumber.js'
 import { Path } from '../utils/path.js'
 import type { ProjectionExpression } from './types.js'
 
+/**
+ * Render paths into a projection expression and name map.
+ */
 export const expressPaths = (paths: string[]): ProjectionExpression => {
   let ProjectionExpression = ''
   const ExpressionAttributeNames: Record<string, string> = {}

--- a/src/schema/actions/parsePaths/pathParser.ts
+++ b/src/schema/actions/parsePaths/pathParser.ts
@@ -6,18 +6,33 @@ import { transformPaths } from './transformPaths.js'
 import type { TransformPathsOptions } from './transformPaths.js'
 import type { ProjectionExpression } from './types.js'
 
+/**
+ * Options accepted by the path parser.
+ */
 export interface ParsePathsOptions extends TransformPathsOptions {}
 
+/**
+ * Compiles attribute paths into a DynamoDB projection expression.
+ */
 export class PathParser<SCHEMA extends Schema = Schema> extends SchemaAction<SCHEMA> {
   static override actionName = 'parsePath' as const
+  /**
+   * Render transformed paths into a projection expression.
+   */
   static express(paths: string[]): ProjectionExpression {
     return expressPaths(paths)
   }
 
+  /**
+   * Map app-level paths to their saved attribute names.
+   */
   transform(paths: string[], options?: TransformPathsOptions): string[] {
     return transformPaths(this.schema, paths, options)
   }
 
+  /**
+   * Compile attribute paths into a projection expression.
+   */
   parse(paths: string[], options?: TransformPathsOptions): ProjectionExpression {
     return PathParser.express(this.transform(paths, options))
   }

--- a/src/schema/actions/parsePaths/transformPaths.ts
+++ b/src/schema/actions/parsePaths/transformPaths.ts
@@ -3,10 +3,16 @@ import { Finder } from '~/schema/actions/finder/index.js'
 import { Deduper } from '~/schema/actions/utils/deduper.js'
 import type { Schema } from '~/schema/index.js'
 
+/**
+ * Options accepted when transforming paths.
+ */
 export interface TransformPathsOptions {
   strict?: boolean
 }
 
+/**
+ * Map app-level paths to their saved attribute names.
+ */
 export const transformPaths = (
   schema: Schema,
   paths: string[],

--- a/src/schema/actions/parsePaths/types.ts
+++ b/src/schema/actions/parsePaths/types.ts
@@ -1,3 +1,6 @@
+/**
+ * A DynamoDB projection expression and its attribute-name map.
+ */
 export interface ProjectionExpression {
   ProjectionExpression: string
   ExpressionAttributeNames: Record<string, string>

--- a/src/schema/actions/utils/deduper.ts
+++ b/src/schema/actions/utils/deduper.ts
@@ -1,17 +1,26 @@
 const JSONSerializer = (value: unknown) =>
   JSON.stringify(value, (_, val) => (typeof val === 'bigint' ? val.toString() : val))
 
+/**
+ * Collect values while dropping duplicates, using a serializer for equality.
+ */
 export class Deduper<VALUE = unknown> {
   values: VALUE[]
   serializedValues: Set<string>
   serializer: (value: VALUE) => string
 
+  /**
+   * Instantiate the deduper, optionally with a custom serializer.
+   */
   constructor({ serializer = JSONSerializer }: { serializer?: (val: VALUE) => string } = {}) {
     this.values = []
     this.serializedValues = new Set()
     this.serializer = serializer
   }
 
+  /**
+   * Add a value, ignoring it if an equal one is already present.
+   */
   push(value: VALUE): boolean {
     const serializedValue = this.serializer(value)
 

--- a/src/schema/actions/utils/errors.ts
+++ b/src/schema/actions/utils/errors.ts
@@ -8,4 +8,7 @@ type InvalidExpressionAttributePathErrorBlueprint = ErrorBlueprint<{
   }
 }>
 
+/**
+ * Union of error blueprints raised by shared schema-action utils.
+ */
 export type SchemaActionUtilsErrorBlueprints = InvalidExpressionAttributePathErrorBlueprint

--- a/src/schema/actions/utils/formatArrayPath.ts
+++ b/src/schema/actions/utils/formatArrayPath.ts
@@ -6,6 +6,9 @@ import type { ArrayPath, StrPath } from './types.js'
 
 const charsToEscape: CharsToEscape[] = ['[', ']', '.']
 
+/**
+ * Render an array path into its string form, escaping special chars.
+ */
 export const formatArrayPath = (arrayPath: ArrayPath): StrPath => {
   let path = ''
   let isRoot = true

--- a/src/schema/actions/utils/parseStringPath.ts
+++ b/src/schema/actions/utils/parseStringPath.ts
@@ -10,6 +10,9 @@ const pathRegex = combineRegExp(listIndexRegex, escapedStrRegex, regularStrRegex
 
 type MatchType = 'regularStr' | 'escapedStr' | 'listIndex'
 
+/**
+ * Split a string path into its array-path parts (keys and list indexes).
+ */
 export const parseStringPath = (strPath: StrPath): ArrayPath => {
   if (strPath === '') {
     return []

--- a/src/schema/actions/utils/path.ts
+++ b/src/schema/actions/utils/path.ts
@@ -2,23 +2,38 @@ import { formatArrayPath } from './formatArrayPath.js'
 import { parseStringPath } from './parseStringPath.js'
 import type { ArrayPath, StrPath } from './types.js'
 
+/**
+ * An attribute path, kept in sync in both array and string forms.
+ */
 export class Path {
   arrayPath: ArrayPath
   strPath: StrPath
 
+  /**
+   * Build a path from its array form.
+   */
   static fromArray(arrayPath: ArrayPath): Path {
     return new Path(formatArrayPath(arrayPath), arrayPath)
   }
 
+  /**
+   * Instantiate a path from its string form (or an empty root path).
+   */
   constructor(strPath = '', arrayPath = parseStringPath(strPath)) {
     this.arrayPath = arrayPath
     this.strPath = formatArrayPath(this.arrayPath)
   }
 
+  /**
+   * Return a new path with the given parts prepended.
+   */
   prepend(...arrayPath: ArrayPath): Path {
     return this.prependPath(Path.fromArray(arrayPath))
   }
 
+  /**
+   * Return a new path with another path prepended.
+   */
   prependPath(path: Path): Path {
     return new Path(
       [path.strPath, this.strPath].filter(Boolean).join(this.strPath[0] !== '[' ? '.' : ''),
@@ -26,10 +41,16 @@ export class Path {
     )
   }
 
+  /**
+   * Return a new path with the given parts appended.
+   */
   append(...arrayPath: ArrayPath): Path {
     return this.appendPath(Path.fromArray(arrayPath))
   }
 
+  /**
+   * Return a new path with another path appended.
+   */
   appendPath(path: Path): Path {
     return new Path(
       [this.strPath, path.strPath].filter(Boolean).join(path.strPath[0] !== '[' ? '.' : ''),

--- a/src/schema/actions/zodSchemer/formatter/any.ts
+++ b/src/schema/actions/zodSchemer/formatter/any.ts
@@ -8,6 +8,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithDecoding, WithOptional } from './utils.js'
 import { withDecoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `any` value.
+ */
 export type AnyZodFormatter<
   SCHEMA extends AnySchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -17,6 +20,9 @@ export type AnyZodFormatter<
   WithOptional<SCHEMA, OPTIONS, WithValidate<SCHEMA, z.ZodType<SCHEMA['props']['castAs']>>>
 >
 
+/**
+ * Build a Zod schema validating a formatted `any` value.
+ */
 export const anyZodFormatter = (schema: AnySchema, options: ZodFormatterOptions): z.ZodTypeAny =>
   withDescribe(
     schema,

--- a/src/schema/actions/zodSchemer/formatter/anyOf.ts
+++ b/src/schema/actions/zodSchemer/formatter/anyOf.ts
@@ -11,6 +11,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { SchemaZodFormatterRec, WithOptional } from './utils.js'
 import { withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `anyOf` value.
+ */
 export type AnyOfZodFormatter<
   SCHEMA extends AnyOfSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -41,6 +44,9 @@ export type AnyOfZodFormatter<
       >
     >
 
+/**
+ * Build a Zod schema validating a formatted `anyOf` value.
+ */
 export const anyOfZodFormatter = (
   schema: AnyOfSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/binary.ts
+++ b/src/schema/actions/zodSchemer/formatter/binary.ts
@@ -9,6 +9,9 @@ import type { WithDecoding, WithOptional } from './utils.js'
 import { withDecoding, withOptional } from './utils.js'
 
 // LIMITATION: Binary enums are not supported
+/**
+ * Zod schema validating a formatted `binary` value.
+ */
 export type BinaryZodFormatter<
   SCHEMA extends BinarySchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -18,6 +21,9 @@ export type BinaryZodFormatter<
   WithOptional<SCHEMA, OPTIONS, WithValidate<SCHEMA, z.ZodType<Uint8Array>>>
 >
 
+/**
+ * Build a Zod schema validating a formatted `binary` value.
+ */
 export const binaryZodFormatter = (
   schema: BinarySchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/boolean.ts
+++ b/src/schema/actions/zodSchemer/formatter/boolean.ts
@@ -9,6 +9,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithDecoding, WithOptional, ZodLiteralMap } from './utils.js'
 import { withDecoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `boolean` value.
+ */
 export type BooleanZodFormatter<
   SCHEMA extends BooleanSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -32,6 +35,9 @@ export type BooleanZodFormatter<
   >
 >
 
+/**
+ * Build a Zod schema validating a formatted `boolean` value.
+ */
 export const booleanZodFormatter = (
   schema: BooleanSchema,
   options: ZodFormatterOptions

--- a/src/schema/actions/zodSchemer/formatter/item.ts
+++ b/src/schema/actions/zodSchemer/formatter/item.ts
@@ -11,6 +11,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithAttributeNameDecoding } from './utils.js'
 import { withAttributeNameDecoding } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `item` value.
+ */
 export type ItemZodFormatter<
   SCHEMA extends ItemSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -32,6 +35,9 @@ export type ItemZodFormatter<
       >
     >
 
+/**
+ * Build a Zod schema validating a formatted `item` value.
+ */
 export const itemZodFormatter = <
   SCHEMA extends ItemSchema,
   OPTIONS extends ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/list.ts
+++ b/src/schema/actions/zodSchemer/formatter/list.ts
@@ -11,6 +11,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithOptional } from './utils.js'
 import { withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `list` value.
+ */
 export type ListZodFormatter<
   SCHEMA extends ListSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -25,6 +28,9 @@ export type ListZodFormatter<
       >
     >
 
+/**
+ * Build a Zod schema validating a formatted `list` value.
+ */
 export const listZodFormatter = (
   schema: ListSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/map.ts
+++ b/src/schema/actions/zodSchemer/formatter/map.ts
@@ -12,6 +12,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithAttributeNameDecoding, WithOptional } from './utils.js'
 import { withAttributeNameDecoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `map` value.
+ */
 export type MapZodFormatter<
   SCHEMA extends MapSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -40,6 +43,9 @@ export type MapZodFormatter<
       >
     >
 
+/**
+ * Build a Zod schema validating a formatted `map` value.
+ */
 export const mapZodFormatter = (
   schema: MapSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/null.ts
+++ b/src/schema/actions/zodSchemer/formatter/null.ts
@@ -8,11 +8,17 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithDecoding, WithOptional } from './utils.js'
 import { withDecoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `null` value.
+ */
 export type NullZodFormatter<
   SCHEMA extends NullSchema,
   OPTIONS extends ZodFormatterOptions = {}
 > = WithDecoding<SCHEMA, OPTIONS, WithOptional<SCHEMA, OPTIONS, WithValidate<SCHEMA, z.ZodNull>>>
 
+/**
+ * Build a Zod schema validating a formatted `null` value.
+ */
 export const nullZodFormatter = (
   schema: NullSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/number.ts
+++ b/src/schema/actions/zodSchemer/formatter/number.ts
@@ -9,6 +9,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithDecoding, WithOptional, ZodLiteralMap } from './utils.js'
 import { withDecoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `number` value.
+ */
 export type NumberZodFormatter<
   SCHEMA extends NumberSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -34,6 +37,9 @@ export type NumberZodFormatter<
   >
 >
 
+/**
+ * Build a Zod schema validating a formatted `number` value.
+ */
 export const numberZodFormatter = (
   schema: NumberSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/record.ts
+++ b/src/schema/actions/zodSchemer/formatter/record.ts
@@ -39,6 +39,9 @@ const withDecodedKeys = (
       ? z.preprocess(compileKeysDecoder(schema), zodSchema)
       : zodSchema
 
+/**
+ * Build a decoder mapping saved record keys back to their app form.
+ */
 export const compileKeysDecoder =
   (schema: RecordSchema) =>
   (encoded: unknown): Record<string, unknown> => {
@@ -52,6 +55,9 @@ export const compileKeysDecoder =
     return decoded
   }
 
+/**
+ * Zod schema validating a formatted `record` value.
+ */
 export type RecordZodFormatter<
   SCHEMA extends RecordSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -89,6 +95,9 @@ export type RecordZodFormatter<
       >
     >
 
+/**
+ * Build a Zod schema validating a formatted `record` value.
+ */
 export const recordZodFormatter = (
   schema: RecordSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/schema.ts
+++ b/src/schema/actions/zodSchemer/formatter/schema.ts
@@ -45,6 +45,9 @@ import type { TupleZodFormatter } from './tuple.js'
 import { tupleZodFormatter } from './tuple.js'
 import type { ZodFormatterOptions } from './types.js'
 
+/**
+ * Zod schema validating a formatted value, for any schema.
+ */
 export type ZodFormatter<
   SCHEMA extends Schema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -54,6 +57,9 @@ export type ZodFormatter<
     ? SchemaZodFormatter<SCHEMA, OPTIONS>
     : never
 
+/**
+ * Zod schema validating a formatted non-item value.
+ */
 export type SchemaZodFormatter<
   SCHEMA extends Schema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -73,39 +79,40 @@ export type SchemaZodFormatter<
       | (SCHEMA extends RecordSchema ? RecordZodFormatter<SCHEMA, OPTIONS> : never)
       | (SCHEMA extends AnyOfSchema ? AnyOfZodFormatter<SCHEMA, OPTIONS> : never)
 
+/**
+ * Dispatch a schema to the Zod formatter of its type.
+ */
 export const schemaZodFormatter = <SCHEMA extends Schema, OPTIONS extends ZodFormatterOptions = {}>(
   schema: SCHEMA,
   options: OPTIONS = {} as OPTIONS
 ): SchemaZodFormatter<SCHEMA, OPTIONS> => {
-  type ZOD_FORMATTER = SchemaZodFormatter<SCHEMA, OPTIONS>
-
   switch (schema.type) {
     case 'any':
-      return anyZodFormatter(schema, options) as ZOD_FORMATTER
+      return anyZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'null':
-      return nullZodFormatter(schema, options) as ZOD_FORMATTER
+      return nullZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'boolean':
-      return booleanZodFormatter(schema, options) as ZOD_FORMATTER
+      return booleanZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'number':
-      return numberZodFormatter(schema, options) as ZOD_FORMATTER
+      return numberZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'string':
-      return stringZodFormatter(schema, options) as ZOD_FORMATTER
+      return stringZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'binary':
-      return binaryZodFormatter(schema, options) as ZOD_FORMATTER
+      return binaryZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'set':
-      return setZodFormatter(schema, options) as ZOD_FORMATTER
+      return setZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'list':
-      return listZodFormatter(schema, options) as ZOD_FORMATTER
+      return listZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'tuple':
-      return tupleZodFormatter(schema, options) as ZOD_FORMATTER
+      return tupleZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'map':
-      return mapZodFormatter(schema, options) as ZOD_FORMATTER
+      return mapZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'record':
-      return recordZodFormatter(schema, options) as ZOD_FORMATTER
+      return recordZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'anyOf':
-      return anyOfZodFormatter(schema, options) as ZOD_FORMATTER
+      return anyOfZodFormatter(schema, options) as SchemaZodFormatter<SCHEMA, OPTIONS>
     case 'item':
       // NOTE: Should not happen
-      return itemZodFormatter(schema, options) as unknown as ZOD_FORMATTER
+      return itemZodFormatter(schema, options) as unknown as SchemaZodFormatter<SCHEMA, OPTIONS>
   }
 }

--- a/src/schema/actions/zodSchemer/formatter/set.ts
+++ b/src/schema/actions/zodSchemer/formatter/set.ts
@@ -11,6 +11,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithOptional } from './utils.js'
 import { withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `set` value.
+ */
 export type SetZodFormatter<
   SCHEMA extends SetSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -25,6 +28,9 @@ export type SetZodFormatter<
       >
     >
 
+/**
+ * Build a Zod schema validating a formatted `set` value.
+ */
 export const setZodFormatter = (
   schema: SetSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/string.ts
+++ b/src/schema/actions/zodSchemer/formatter/string.ts
@@ -8,6 +8,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { WithDecoding, WithOptional } from './utils.js'
 import { withDecoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `string` value.
+ */
 export type StringZodFormatter<
   SCHEMA extends StringSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -28,6 +31,9 @@ export type StringZodFormatter<
   >
 >
 
+/**
+ * Build a Zod schema validating a formatted `string` value.
+ */
 export const stringZodFormatter = (
   schema: StringSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/tuple.ts
+++ b/src/schema/actions/zodSchemer/formatter/tuple.ts
@@ -11,6 +11,9 @@ import type { ZodFormatterOptions } from './types.js'
 import type { SchemaZodFormatterRec, WithOptional } from './utils.js'
 import { withOptional } from './utils.js'
 
+/**
+ * Zod schema validating a formatted `tuple` value.
+ */
 export type TupleZodFormatter<
   SCHEMA extends TupleSchema,
   OPTIONS extends ZodFormatterOptions = {}
@@ -36,6 +39,9 @@ export type TupleZodFormatter<
       >
     >
 
+/**
+ * Build a Zod schema validating a formatted `tuple` value.
+ */
 export const tupleZodFormatter = (
   schema: TupleSchema,
   options: ZodFormatterOptions = {}

--- a/src/schema/actions/zodSchemer/formatter/types.ts
+++ b/src/schema/actions/zodSchemer/formatter/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Options driving how a Zod formatter is built.
+ */
 export interface ZodFormatterOptions {
   transform?: boolean
   format?: boolean

--- a/src/schema/actions/zodSchemer/formatter/utils.ts
+++ b/src/schema/actions/zodSchemer/formatter/utils.ts
@@ -8,6 +8,9 @@ import type { SavedAsAttributes } from '../utils.js'
 import type { SchemaZodFormatter } from './schema.js'
 import type { ZodFormatterOptions } from './types.js'
 
+/**
+ * Zod formatters of a tuple of schemas, preserving positions.
+ */
 export type SchemaZodFormatterRec<
   SCHEMAS extends Schema[],
   OPTIONS extends ZodFormatterOptions = {},
@@ -24,6 +27,9 @@ export type SchemaZodFormatterRec<
     : never
   : RESULTS
 
+/**
+ * Zod literals of a tuple of primitives, preserving positions.
+ */
 export type ZodLiteralMap<
   LITERALS extends z.Primitive[],
   RESULTS extends z.ZodLiteral<z.Primitive>[] = []
@@ -35,6 +41,9 @@ export type ZodLiteralMap<
     : never
   : RESULTS
 
+/**
+ * Wrap a Zod schema as optional unless the value is always defined.
+ */
 export type WithOptional<
   SCHEMA extends Schema,
   OPTIONS extends ZodFormatterOptions,
@@ -49,6 +58,9 @@ export type WithOptional<
   >
 >
 
+/**
+ * Make a Zod schema optional unless the value is always defined.
+ */
 export const withOptional = (
   schema: Schema,
   { partial, defined }: ZodFormatterOptions,
@@ -60,6 +72,9 @@ export const withOptional = (
       ? z.optional(zodSchema)
       : zodSchema
 
+/**
+ * Wrap a Zod schema to reverse the attribute's transformer on read.
+ */
 export type WithDecoding<
   SCHEMA extends Schema,
   OPTIONS extends ZodFormatterOptions,
@@ -74,6 +89,9 @@ export type WithDecoding<
   >
 >
 
+/**
+ * Preprocess a Zod schema to reverse the attribute's transformer on read.
+ */
 export const withDecoding = (
   schema: Extract<Schema, { props: { transform?: unknown } }>,
   { transform }: ZodFormatterOptions,
@@ -85,6 +103,9 @@ export const withDecoding = (
       ? z.preprocess(encoded => (schema.props.transform as Transformer).decode(encoded), zodSchema)
       : zodSchema
 
+/**
+ * Wrap a Zod schema to map saved attribute names back to their keys.
+ */
 export type WithAttributeNameDecoding<
   SCHEMA extends MapSchema | ItemSchema,
   OPTIONS extends ZodFormatterOptions,
@@ -95,6 +116,9 @@ export type WithAttributeNameDecoding<
   z.ZodEffects<ZOD_SCHEMA, z.output<ZOD_SCHEMA>, TransformedValue<SCHEMA>>
 >
 
+/**
+ * Preprocess a Zod schema to map saved attribute names back to their keys.
+ */
 export const withAttributeNameDecoding = (
   schema: MapSchema | ItemSchema,
   { transform }: ZodFormatterOptions,
@@ -105,6 +129,9 @@ export const withAttributeNameDecoding = (
     ? zodSchema
     : z.preprocess(compileAttributeNameDecoder(schema), zodSchema)
 
+/**
+ * Build a decoder mapping saved attribute names back to their keys.
+ */
 export const compileAttributeNameDecoder =
   (schema: MapSchema | ItemSchema) =>
   (encoded: unknown): Record<string, unknown> => {

--- a/src/schema/actions/zodSchemer/parser/any.ts
+++ b/src/schema/actions/zodSchemer/parser/any.ts
@@ -8,6 +8,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithDefault, WithEncoding, WithOptional } from './utils.js'
 import { withDefault, withEncoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `any` value.
+ */
 export type AnyZodParser<
   SCHEMA extends AnySchema,
   OPTIONS extends ZodParserOptions = {}
@@ -21,6 +24,9 @@ export type AnyZodParser<
   >
 >
 
+/**
+ * Build a Zod schema validating an input `any` value.
+ */
 export const anyZodParser = (schema: AnySchema, options: ZodParserOptions): z.ZodTypeAny =>
   withDescribe(
     schema,

--- a/src/schema/actions/zodSchemer/parser/anyOf.ts
+++ b/src/schema/actions/zodSchemer/parser/anyOf.ts
@@ -11,6 +11,9 @@ import type { ZodParserOptions } from './types.js'
 import type { SchemaZodParserRec, WithDefault, WithOptional } from './utils.js'
 import { withDefault, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `anyOf` value.
+ */
 export type AnyOfZodParser<
   SCHEMA extends AnyOfSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -45,6 +48,9 @@ export type AnyOfZodParser<
       >
     >
 
+/**
+ * Build a Zod schema validating an input `anyOf` value.
+ */
 export const anyOfZodParser = (
   schema: AnyOfSchema,
   options: ZodParserOptions = {}

--- a/src/schema/actions/zodSchemer/parser/binary.ts
+++ b/src/schema/actions/zodSchemer/parser/binary.ts
@@ -8,6 +8,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithDefault, WithEncoding, WithOptional } from './utils.js'
 import { withDefault, withEncoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `binary` value.
+ */
 export type BinaryZodParser<
   SCHEMA extends BinarySchema,
   OPTIONS extends ZodParserOptions = {}
@@ -21,6 +24,9 @@ export type BinaryZodParser<
   >
 >
 
+/**
+ * Build a Zod schema validating an input `binary` value.
+ */
 export const binaryZodParser = (
   schema: BinarySchema,
   options: ZodParserOptions = {}

--- a/src/schema/actions/zodSchemer/parser/boolean.ts
+++ b/src/schema/actions/zodSchemer/parser/boolean.ts
@@ -9,6 +9,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithDefault, WithEncoding, WithOptional, ZodLiteralMap } from './utils.js'
 import { withDefault, withEncoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `boolean` value.
+ */
 export type BooleanZodParser<
   SCHEMA extends BooleanSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -36,6 +39,9 @@ export type BooleanZodParser<
   >
 >
 
+/**
+ * Build a Zod schema validating an input `boolean` value.
+ */
 export const booleanZodParser = (
   schema: BooleanSchema,
   options: ZodParserOptions

--- a/src/schema/actions/zodSchemer/parser/item.ts
+++ b/src/schema/actions/zodSchemer/parser/item.ts
@@ -11,6 +11,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithAttributeNameEncoding } from './utils.js'
 import { withAttributeNameEncoding } from './utils.js'
 
+/**
+ * Zod schema validating an input `item` value.
+ */
 export type ItemZodParser<
   SCHEMA extends ItemSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -32,6 +35,9 @@ export type ItemZodParser<
       >
     >
 
+/**
+ * Build a Zod schema validating an input `item` value.
+ */
 export const itemZodParser = <SCHEMA extends ItemSchema, OPTIONS extends ZodParserOptions = {}>(
   schema: SCHEMA,
   options: OPTIONS = {} as OPTIONS

--- a/src/schema/actions/zodSchemer/parser/list.ts
+++ b/src/schema/actions/zodSchemer/parser/list.ts
@@ -11,6 +11,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithDefault, WithOptional } from './utils.js'
 import { withDefault, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `list` value.
+ */
 export type ListZodParser<
   SCHEMA extends ListSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -29,6 +32,9 @@ export type ListZodParser<
       >
     >
 
+/**
+ * Build a Zod schema validating an input `list` value.
+ */
 export const listZodParser = (schema: ListSchema, options: ZodParserOptions = {}): z.ZodTypeAny =>
   withDescribe(
     schema,

--- a/src/schema/actions/zodSchemer/parser/map.ts
+++ b/src/schema/actions/zodSchemer/parser/map.ts
@@ -12,6 +12,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithAttributeNameEncoding, WithDefault, WithOptional } from './utils.js'
 import { withAttributeNameEncoding, withDefault, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `map` value.
+ */
 export type MapZodParser<
   SCHEMA extends MapSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -44,6 +47,9 @@ export type MapZodParser<
       >
     >
 
+/**
+ * Build a Zod schema validating an input `map` value.
+ */
 export const mapZodParser = (schema: MapSchema, options: ZodParserOptions = {}): z.ZodTypeAny => {
   const { mode = 'put' } = options
 

--- a/src/schema/actions/zodSchemer/parser/null.ts
+++ b/src/schema/actions/zodSchemer/parser/null.ts
@@ -8,6 +8,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithDefault, WithEncoding, WithOptional } from './utils.js'
 import { withDefault, withEncoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `null` value.
+ */
 export type NullZodParser<
   SCHEMA extends NullSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -17,6 +20,9 @@ export type NullZodParser<
   WithDefault<SCHEMA, OPTIONS, WithOptional<SCHEMA, OPTIONS, WithValidate<SCHEMA, z.ZodNull>>>
 >
 
+/**
+ * Build a Zod schema validating an input `null` value.
+ */
 export const nullZodParser = (schema: NullSchema, options: ZodParserOptions = {}): z.ZodTypeAny =>
   withDescribe(
     schema,

--- a/src/schema/actions/zodSchemer/parser/number.ts
+++ b/src/schema/actions/zodSchemer/parser/number.ts
@@ -9,6 +9,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithDefault, WithEncoding, WithOptional, ZodLiteralMap } from './utils.js'
 import { withDefault, withEncoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `number` value.
+ */
 export type NumberZodParser<
   SCHEMA extends NumberSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -38,6 +41,9 @@ export type NumberZodParser<
   >
 >
 
+/**
+ * Build a Zod schema validating an input `number` value.
+ */
 export const numberZodParser = (
   schema: NumberSchema,
   options: ZodParserOptions = {}

--- a/src/schema/actions/zodSchemer/parser/record.ts
+++ b/src/schema/actions/zodSchemer/parser/record.ts
@@ -39,6 +39,9 @@ const withEncodedKeys = (
       ? zodSchema.transform(compileKeysEncoder(schema))
       : zodSchema
 
+/**
+ * Build an encoder mapping record keys to their saved form.
+ */
 export const compileKeysEncoder =
   (schema: RecordSchema) =>
   (decoded: unknown): Record<string, unknown> => {
@@ -52,6 +55,9 @@ export const compileKeysEncoder =
     return encoded
   }
 
+/**
+ * Zod schema validating an input `record` value.
+ */
 export type RecordZodParser<
   SCHEMA extends RecordSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -93,6 +99,9 @@ export type RecordZodParser<
       >
     >
 
+/**
+ * Build a Zod schema validating an input `record` value.
+ */
 export const recordZodParser = (
   schema: RecordSchema,
   options: ZodParserOptions = {}

--- a/src/schema/actions/zodSchemer/parser/schema.ts
+++ b/src/schema/actions/zodSchemer/parser/schema.ts
@@ -45,6 +45,9 @@ import type { TupleZodParser } from './tuple.js'
 import { tupleZodParser } from './tuple.js'
 import type { ZodParserOptions } from './types.js'
 
+/**
+ * Zod schema validating an input value, for any schema.
+ */
 export type ZodParser<
   SCHEMA extends Schema,
   OPTIONS extends ZodParserOptions = {}
@@ -54,6 +57,9 @@ export type ZodParser<
     ? SchemaZodParser<SCHEMA, OPTIONS>
     : never
 
+/**
+ * Zod schema validating an input non-item value.
+ */
 export type SchemaZodParser<
   SCHEMA extends Schema,
   OPTIONS extends ZodParserOptions = {}
@@ -73,39 +79,40 @@ export type SchemaZodParser<
       | (SCHEMA extends RecordSchema ? RecordZodParser<SCHEMA, OPTIONS> : never)
       | (SCHEMA extends AnyOfSchema ? AnyOfZodParser<SCHEMA, OPTIONS> : never)
 
+/**
+ * Dispatch a schema to the Zod parser of its type.
+ */
 export const schemaZodParser = <SCHEMA extends Schema, OPTIONS extends ZodParserOptions = {}>(
   schema: SCHEMA,
   options: OPTIONS = {} as OPTIONS
 ): SchemaZodParser<SCHEMA, OPTIONS> => {
-  type ZOD_PARSER = SchemaZodParser<SCHEMA, OPTIONS>
-
   switch (schema.type) {
     case 'any':
-      return anyZodParser(schema, options) as ZOD_PARSER
+      return anyZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'null':
-      return nullZodParser(schema, options) as ZOD_PARSER
+      return nullZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'boolean':
-      return booleanZodParser(schema, options) as ZOD_PARSER
+      return booleanZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'number':
-      return numberZodParser(schema, options) as ZOD_PARSER
+      return numberZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'string':
-      return stringZodParser(schema, options) as ZOD_PARSER
+      return stringZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'binary':
-      return binaryZodParser(schema, options) as ZOD_PARSER
+      return binaryZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'set':
-      return setZodParser(schema, options) as ZOD_PARSER
+      return setZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'list':
-      return listZodParser(schema, options) as ZOD_PARSER
+      return listZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'tuple':
-      return tupleZodParser(schema, options) as ZOD_PARSER
+      return tupleZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'map':
-      return mapZodParser(schema, options) as ZOD_PARSER
+      return mapZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'record':
-      return recordZodParser(schema, options) as ZOD_PARSER
+      return recordZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'anyOf':
-      return anyOfZodParser(schema, options) as ZOD_PARSER
+      return anyOfZodParser(schema, options) as SchemaZodParser<SCHEMA, OPTIONS>
     case 'item':
       // NOTE: Should not happen
-      return itemZodParser(schema, options) as unknown as ZOD_PARSER
+      return itemZodParser(schema, options) as unknown as SchemaZodParser<SCHEMA, OPTIONS>
   }
 }

--- a/src/schema/actions/zodSchemer/parser/set.ts
+++ b/src/schema/actions/zodSchemer/parser/set.ts
@@ -11,6 +11,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithDefault, WithOptional } from './utils.js'
 import { withDefault, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `set` value.
+ */
 export type SetZodParser<
   SCHEMA extends SetSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -29,6 +32,9 @@ export type SetZodParser<
       >
     >
 
+/**
+ * Build a Zod schema validating an input `set` value.
+ */
 export const setZodParser = (schema: SetSchema, options: ZodParserOptions = {}): z.ZodTypeAny =>
   withDescribe(
     schema,

--- a/src/schema/actions/zodSchemer/parser/string.ts
+++ b/src/schema/actions/zodSchemer/parser/string.ts
@@ -8,6 +8,9 @@ import type { ZodParserOptions } from './types.js'
 import type { WithDefault, WithEncoding, WithOptional } from './utils.js'
 import { withDefault, withEncoding, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `string` value.
+ */
 export type StringZodParser<
   SCHEMA extends StringSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -32,6 +35,9 @@ export type StringZodParser<
   >
 >
 
+/**
+ * Build a Zod schema validating an input `string` value.
+ */
 export const stringZodParser = (
   schema: StringSchema,
   options: ZodParserOptions = {}

--- a/src/schema/actions/zodSchemer/parser/tuple.ts
+++ b/src/schema/actions/zodSchemer/parser/tuple.ts
@@ -11,6 +11,9 @@ import type { ZodParserOptions } from './types.js'
 import type { SchemaZodParserRec, WithDefault, WithOptional } from './utils.js'
 import { withDefault, withOptional } from './utils.js'
 
+/**
+ * Zod schema validating an input `tuple` value.
+ */
 export type TupleZodParser<
   SCHEMA extends TupleSchema,
   OPTIONS extends ZodParserOptions = {}
@@ -40,6 +43,9 @@ export type TupleZodParser<
       >
     >
 
+/**
+ * Build a Zod schema validating an input `tuple` value.
+ */
 export const tupleZodParser = (schema: TupleSchema, options: ZodParserOptions = {}): z.ZodTypeAny =>
   withDescribe(
     schema,

--- a/src/schema/actions/zodSchemer/parser/types.ts
+++ b/src/schema/actions/zodSchemer/parser/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Options driving how a Zod parser is built.
+ */
 export interface ZodParserOptions {
   transform?: boolean
   defined?: boolean

--- a/src/schema/actions/zodSchemer/parser/utils.ts
+++ b/src/schema/actions/zodSchemer/parser/utils.ts
@@ -8,6 +8,9 @@ import type { SavedAsAttributes } from '../utils.js'
 import type { SchemaZodParser } from './schema.js'
 import type { ZodParserOptions } from './types.js'
 
+/**
+ * Zod parsers of a tuple of schemas, preserving positions.
+ */
 export type SchemaZodParserRec<
   SCHEMAS extends Schema[],
   OPTIONS extends ZodParserOptions = {},
@@ -24,6 +27,9 @@ export type SchemaZodParserRec<
     : never
   : RESULTS
 
+/**
+ * Zod literals of a tuple of primitives, preserving positions.
+ */
 export type ZodLiteralMap<
   LITERALS extends z.Primitive[],
   RESULTS extends z.ZodLiteral<z.Primitive>[] = []
@@ -35,6 +41,9 @@ export type ZodLiteralMap<
     : never
   : RESULTS
 
+/**
+ * Wrap a Zod schema with the schema's default value, if any.
+ */
 export type WithDefault<
   SCHEMA extends Schema,
   OPTIONS extends ZodParserOptions,
@@ -52,6 +61,9 @@ export type WithDefault<
   >
 >
 
+/**
+ * Apply the schema's default value to a Zod schema.
+ */
 export const withDefault = (
   schema: Schema,
   { fill }: ZodParserOptions,
@@ -65,6 +77,9 @@ export const withDefault = (
         ? zodSchema.default(schema.props.putDefault)
         : zodSchema
 
+/**
+ * Wrap a Zod schema as optional unless the value is always defined.
+ */
 export type WithOptional<
   SCHEMA extends Schema,
   OPTIONS extends ZodParserOptions,
@@ -75,6 +90,9 @@ export type WithOptional<
   If<Extends<SCHEMA['props'], { required: 'never' }>, z.ZodOptional<ZOD_SCHEMA>, ZOD_SCHEMA>
 >
 
+/**
+ * Make a Zod schema optional unless the value is always defined.
+ */
 export const withOptional = (
   schema: Schema,
   { defined }: ZodParserOptions,
@@ -86,6 +104,9 @@ export const withOptional = (
       ? z.optional(zodSchema)
       : zodSchema
 
+/**
+ * Wrap a Zod schema to apply the attribute's transformer on write.
+ */
 export type WithEncoding<
   SCHEMA extends Schema,
   OPTIONS extends ZodParserOptions,
@@ -100,6 +121,9 @@ export type WithEncoding<
   >
 >
 
+/**
+ * Transform a Zod schema to apply the attribute's transformer on write.
+ */
 export const withEncoding = (
   schema: Extract<Schema, { props: { transform?: unknown } }>,
   { transform }: ZodParserOptions,
@@ -111,6 +135,9 @@ export const withEncoding = (
       ? zodSchema.transform(decoded => (schema.props.transform as Transformer).encode(decoded))
       : zodSchema
 
+/**
+ * Wrap a Zod schema to map attribute keys to their saved names.
+ */
 export type WithAttributeNameEncoding<
   SCHEMA extends MapSchema | ItemSchema,
   OPTIONS extends ZodParserOptions,
@@ -121,6 +148,9 @@ export type WithAttributeNameEncoding<
   z.ZodEffects<ZOD_SCHEMA, TransformedValue<SCHEMA>, z.input<ZOD_SCHEMA>>
 >
 
+/**
+ * Transform a Zod schema to map attribute keys to their saved names.
+ */
 export const withAttributeNameEncoding = (
   schema: MapSchema | ItemSchema,
   { transform }: ZodParserOptions,
@@ -131,6 +161,9 @@ export const withAttributeNameEncoding = (
     ? zodSchema
     : zodSchema.transform(compileAttributeNameEncoder(schema))
 
+/**
+ * Build an encoder mapping attribute keys to their saved names.
+ */
 export const compileAttributeNameEncoder =
   (schema: MapSchema | ItemSchema) =>
   (decoded: unknown): Record<string, unknown> => {

--- a/src/schema/actions/zodSchemer/utils.ts
+++ b/src/schema/actions/zodSchemer/utils.ts
@@ -3,6 +3,9 @@ import type { z } from 'zod'
 import type { ItemSchema, MapSchema, Schema, Validator } from '~/schema/index.js'
 import type { Extends, If, Or } from '~/types/index.js'
 
+/**
+ * Attribute keys of a `map`/`item` renamed via `savedAs`.
+ */
 export type SavedAsAttributes<SCHEMA extends MapSchema | ItemSchema> = {
   [KEY in keyof SCHEMA['attributes']]: SCHEMA['attributes'][KEY]['props'] extends {
     savedAs: string
@@ -11,6 +14,9 @@ export type SavedAsAttributes<SCHEMA extends MapSchema | ItemSchema> = {
     : never
 }[keyof SCHEMA['attributes']]
 
+/**
+ * Wrap a Zod schema with the schema's custom validator, if any.
+ */
 export type WithValidate<SCHEMA extends Schema, ZOD_SCHEMA extends z.ZodTypeAny> = If<
   Or<
     Extends<SCHEMA['props'], { key: true; keyValidator: Validator }>,
@@ -20,6 +26,9 @@ export type WithValidate<SCHEMA extends Schema, ZOD_SCHEMA extends z.ZodTypeAny>
   ZOD_SCHEMA
 >
 
+/**
+ * Apply the schema's custom validator to a Zod schema.
+ */
 export const withValidate = (schema: Schema, zodSchema: z.ZodTypeAny): z.ZodTypeAny => {
   const { key = false, keyValidator, putValidator } = schema.props
 
@@ -34,6 +43,9 @@ export const withValidate = (schema: Schema, zodSchema: z.ZodTypeAny): z.ZodType
   return zodSchema
 }
 
+/**
+ * Apply the schema's meta description to a Zod schema.
+ */
 export const withDescribe = (schema: Schema, zodSchema: z.ZodTypeAny): z.ZodTypeAny => {
   const { meta } = schema.props
 

--- a/src/schema/actions/zodSchemer/zodSchemer.ts
+++ b/src/schema/actions/zodSchemer/zodSchemer.ts
@@ -6,9 +6,15 @@ import type { ZodFormatter, ZodFormatterOptions } from './formatter/index.js'
 import { itemZodParser, schemaZodParser } from './parser/index.js'
 import type { ZodParser, ZodParserOptions } from './parser/index.js'
 
+/**
+ * Derive Zod schemas (parser + formatter) from a schema.
+ */
 export class ZodSchemer<SCHEMA extends Schema = Schema> extends SchemaAction<SCHEMA> {
   static override actionName = 'zodSchemer' as const
 
+  /**
+   * Build the Zod schema validating formatted (read) values.
+   */
   formatter<OPTIONS extends ZodFormatterOptions = {}>(
     options: OPTIONS = {} as OPTIONS
   ): ZodFormatter<SCHEMA, OPTIONS> {
@@ -19,6 +25,9 @@ export class ZodSchemer<SCHEMA extends Schema = Schema> extends SchemaAction<SCH
     }
   }
 
+  /**
+   * Build the Zod schema validating input (write) values.
+   */
   parser<OPTIONS extends ZodParserOptions = {}>(
     options: OPTIONS = {} as OPTIONS
   ): ZodParser<SCHEMA, OPTIONS> {

--- a/src/schema/any/resolve.ts
+++ b/src/schema/any/resolve.ts
@@ -1,3 +1,6 @@
 import type { AnySchema } from './schema.js'
 
+/**
+ * Resolves an `any` schema to its runtime type.
+ */
 export type ResolveAnySchema<SCHEMA extends AnySchema> = SCHEMA['props']['castAs']

--- a/src/schema/any/schema.ts
+++ b/src/schema/any/schema.ts
@@ -1,19 +1,31 @@
 import { checkSchemaProps } from '../utils/checkSchemaProps.js'
 import type { AnySchemaProps } from './types.js'
 
+/**
+ * Schema for an attribute of any type.
+ */
 export class AnySchema<PROPS extends AnySchemaProps = AnySchemaProps> {
   type: 'any'
   props: PROPS
 
+  /**
+   * Instantiate the schema from its props.
+   */
   constructor(props: PROPS) {
     this.type = 'any'
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/any/types.ts
+++ b/src/schema/any/types.ts
@@ -1,5 +1,8 @@
 import type { SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by an `any` schema.
+ */
 export interface AnySchemaProps extends SchemaProps {
   castAs?: unknown
   transform?: undefined | unknown

--- a/src/schema/anyOf/constants.ts
+++ b/src/schema/anyOf/constants.ts
@@ -1,11 +1,15 @@
 export const $discriminators_ = Symbol('$discriminators_')
+/** Cache key for the computed discriminators (attribute name to savedAs). */
 export type $discriminators_ = typeof $discriminators_
 
 export const $discriminators = Symbol('$discriminators')
+/** Getter key for the discriminators shared by all elements. */
 export type $discriminators = typeof $discriminators
 
 export const $discriminations_ = Symbol('$discriminations_')
+/** Cache key for the computed discriminations (discriminator value to schema). */
 export type $discriminations_ = typeof $discriminations_
 
 export const $computed = Symbol('$computed')
+/** Flag key marking a discriminator cache as computed. */
 export type $computed = typeof $computed

--- a/src/schema/anyOf/errors.ts
+++ b/src/schema/anyOf/errors.ts
@@ -44,6 +44,9 @@ type InvalidDiscriminatorErrorBlueprint = ErrorBlueprint<{
   }
 }>
 
+/**
+ * Union of the error blueprints raised when validating an anyOf schema.
+ */
 export type AnyOfSchemaErrorBlueprint =
   | InvalidElementsErrorBlueprint
   | MissingElementsErrorBlueprint

--- a/src/schema/anyOf/schema.ts
+++ b/src/schema/anyOf/schema.ts
@@ -7,6 +7,9 @@ import { hasDefinedDefault } from '../utils/hasDefinedDefault.js'
 import { $computed, $discriminations_, $discriminators, $discriminators_ } from './constants.js'
 import type { AnyOfSchemaProps } from './types.js'
 
+/**
+ * Schema for an anyOf (union) attribute.
+ */
 export class AnyOfSchema<
   ELEMENTS extends Schema[] = Schema[],
   PROPS extends AnyOfSchemaProps = AnyOfSchemaProps
@@ -19,6 +22,9 @@ export class AnyOfSchema<
   [$discriminators_]: Record<string, string> & { [$computed]: boolean };
   [$discriminations_]: Record<string, Schema> & { [$computed]: boolean }
 
+  /**
+   * Instantiate the schema from its elements and props.
+   */
   constructor(elements: ELEMENTS, props: PROPS) {
     this.type = 'anyOf'
     this.elements = elements
@@ -28,10 +34,16 @@ export class AnyOfSchema<
     this[$discriminations_] = { [$computed]: false }
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and elements, then freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return
@@ -118,6 +130,9 @@ export class AnyOfSchema<
     Object.freeze(this.elements)
   }
 
+  /**
+   * Discriminator attributes shared by all elements (name to savedAs).
+   */
   get [$discriminators](): Record<string, string> {
     if (!this[$discriminators_][$computed]) {
       Object.assign(
@@ -130,6 +145,9 @@ export class AnyOfSchema<
     return this[$discriminators_]
   }
 
+  /**
+   * Find the element schema matching a discriminator value.
+   */
   match(value: string): Schema | undefined {
     if (!this[$discriminations_][$computed]) {
       const { discriminator } = this.props

--- a/src/schema/anyOf/types.ts
+++ b/src/schema/anyOf/types.ts
@@ -26,6 +26,9 @@ type ElementDiscriminator<ELEMENT extends Schema> = Schema extends ELEMENT
             }[keyof ELEMENT['attributes']]
           : never)
 
+/**
+ * Valid discriminator keys shared by a list of element schemas.
+ */
 export type Discriminator<
   ELEMENTS extends Schema[],
   RESULTS extends [string, string] = [string, string]
@@ -39,6 +42,9 @@ export type Discriminator<
       : never
     : RESULTS[0]
 
+/**
+ * Props accepted by an anyOf schema.
+ */
 export interface AnyOfSchemaProps extends SchemaProps {
   discriminator?: string
 }
@@ -56,4 +62,7 @@ interface AnyOfElementProps extends SchemaProps {
 }
 
 // TODO: Re-introduce constraint in interface (not only in typer)
+/**
+ * Schema allowed as an anyOf element.
+ */
 export type AnyOfElementSchema = Schema & { props: AnyOfElementProps }

--- a/src/schema/binary/resolve.ts
+++ b/src/schema/binary/resolve.ts
@@ -1,9 +1,15 @@
 import type { BinarySchema } from './schema.js'
 
+/**
+ * Resolves a binary schema to its runtime type.
+ */
 export type ResolveBinarySchema<SCHEMA extends BinarySchema> = SCHEMA['props'] extends {
   enum: Uint8Array[]
 }
   ? SCHEMA['props']['enum'][number]
   : Uint8Array
 
+/**
+ * Runtime type of a binary schema (`Uint8Array`).
+ */
 export type ResolvedBinarySchema = ResolveBinarySchema<BinarySchema>

--- a/src/schema/binary/schema.ts
+++ b/src/schema/binary/schema.ts
@@ -1,19 +1,31 @@
 import { checkPrimitiveSchema } from '../primitive/check.js'
 import type { BinarySchemaProps } from './types.js'
 
+/**
+ * Schema for a binary attribute.
+ */
 export class BinarySchema<PROPS extends BinarySchemaProps = BinarySchemaProps> {
   type: 'binary'
   props: PROPS
 
+  /**
+   * Instantiate the schema from its props.
+   */
   constructor(props: PROPS) {
     this.type = 'binary'
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/binary/types.ts
+++ b/src/schema/binary/types.ts
@@ -1,5 +1,8 @@
 import type { SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by a binary schema.
+ */
 export interface BinarySchemaProps extends SchemaProps {
   enum?: Uint8Array[]
   transform?: unknown

--- a/src/schema/boolean/resolve.ts
+++ b/src/schema/boolean/resolve.ts
@@ -1,9 +1,15 @@
 import type { BooleanSchema } from './schema.js'
 
+/**
+ * Resolves a boolean schema to its runtime type.
+ */
 export type ResolveBooleanSchema<SCHEMA extends BooleanSchema> = SCHEMA['props'] extends {
   enum: boolean[]
 }
   ? SCHEMA['props']['enum'][number]
   : boolean
 
+/**
+ * Runtime type of a boolean schema (`boolean`).
+ */
 export type ResolvedBooleanSchema = ResolveBooleanSchema<BooleanSchema>

--- a/src/schema/boolean/schema.ts
+++ b/src/schema/boolean/schema.ts
@@ -1,19 +1,31 @@
 import { checkPrimitiveSchema } from '../primitive/check.js'
 import type { BooleanSchemaProps } from './types.js'
 
+/**
+ * Schema for a boolean attribute.
+ */
 export class BooleanSchema<PROPS extends BooleanSchemaProps = BooleanSchemaProps> {
   type: 'boolean'
   props: PROPS
 
+  /**
+   * Instantiate the schema from its props.
+   */
   constructor(props: PROPS) {
     this.type = 'boolean'
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/boolean/types.ts
+++ b/src/schema/boolean/types.ts
@@ -1,5 +1,8 @@
 import type { SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by a boolean schema.
+ */
 export interface BooleanSchemaProps extends SchemaProps {
   enum?: boolean[]
   transform?: unknown

--- a/src/schema/errors.ts
+++ b/src/schema/errors.ts
@@ -9,6 +9,9 @@ import type { SetSchemaErrorBlueprint } from './set/errors.js'
 import type { TupleSchemaErrorBlueprint } from './tuple/errors.js'
 import type { SharedSchemaErrorBlueprint } from './utils/errors.js'
 
+/**
+ * Union of every error blueprint raised when validating a schema.
+ */
 export type SchemaErrorBlueprints =
   | PrimitiveSchemaErrorBlueprint
   | SetSchemaErrorBlueprint

--- a/src/schema/item/errors.ts
+++ b/src/schema/item/errors.ts
@@ -6,4 +6,7 @@ type DuplicateSavedAsErrorBlueprint = ErrorBlueprint<{
   payload: { savedAs: string }
 }>
 
+/**
+ * Error blueprint raised when validating an item schema.
+ */
 export type ItemSchemaErrorBlueprints = DuplicateSavedAsErrorBlueprint

--- a/src/schema/item/schema.ts
+++ b/src/schema/item/schema.ts
@@ -5,6 +5,9 @@ import type { SchemaRequiredProp } from '../types/index.js'
 import { checkSchemaProps } from '../utils/checkSchemaProps.js'
 import type { ItemAttributes, ItemSchemaProps } from './types.js'
 
+/**
+ * Schema for an item, the root object an entity is built from.
+ */
 export class ItemSchema<
   ATTRIBUTES extends ItemAttributes = ItemAttributes,
   PROPS extends ItemSchemaProps = ItemSchemaProps
@@ -17,6 +20,9 @@ export class ItemSchema<
   keyAttributeNames: Set<string>
   requiredAttributeNames: Record<SchemaRequiredProp, Set<string>>
 
+  /**
+   * Instantiate the schema from its attributes and props.
+   */
   constructor(attributes: ATTRIBUTES, props: PROPS = {} as PROPS) {
     this.type = 'item'
     this.attributes = attributes
@@ -41,10 +47,16 @@ export class ItemSchema<
     }
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and attributes, then freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/item/schema_.ts
+++ b/src/schema/item/schema_.ts
@@ -22,6 +22,9 @@ export const item: ItemSchemer = <ATTRIBUTES extends ItemAttributes>(
   attributes: NarrowObject<ATTRIBUTES>
 ) => new ItemSchema_(lightObj(attributes))
 
+/**
+ * Builder (warm) variant of an item schema.
+ */
 export class ItemSchema_<
   ATTRIBUTES extends ItemAttributes = ItemAttributes,
   PROPS extends ItemSchemaProps = ItemSchemaProps
@@ -44,6 +47,9 @@ export class ItemSchema_<
     return new ItemSchema_(this.attributes, overwrite(this.props, { meta: nextMeta }))
   }
 
+  /**
+   * Return a new schema with only the given attributes.
+   */
   pick<ATTRIBUTE_NAMES extends (keyof ATTRIBUTES)[]>(
     ...attributeNames: ATTRIBUTE_NAMES
   ): ItemSchema_<{ [KEY in ATTRIBUTE_NAMES[number]]: ResetLinks<ATTRIBUTES[KEY]> }, PROPS> {
@@ -62,6 +68,9 @@ export class ItemSchema_<
     return new ItemSchema_(nextAttributes, this.props)
   }
 
+  /**
+   * Return a new schema without the given attributes.
+   */
   omit<ATTRIBUTE_NAMES extends (keyof ATTRIBUTES)[]>(
     ...attributeNames: ATTRIBUTE_NAMES
   ): ItemSchema_<
@@ -85,6 +94,9 @@ export class ItemSchema_<
     return new ItemSchema_(nextAttributes, this.props)
   }
 
+  /**
+   * Return a new schema with additional attributes merged in.
+   */
   and<ADDITIONAL_ATTRIBUTES extends ItemAttributes = ItemAttributes>(
     additionalAttr:
       | NarrowObject<ADDITIONAL_ATTRIBUTES>
@@ -125,6 +137,9 @@ export class ItemSchema_<
     )
   }
 
+  /**
+   * Build an action from this schema.
+   */
   build<ACTION extends SchemaAction<this> = SchemaAction<this>>(
     Action: new (schema: this) => ACTION
   ): ACTION {

--- a/src/schema/item/types.ts
+++ b/src/schema/item/types.ts
@@ -1,9 +1,15 @@
 import type { Schema, SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by an item schema.
+ */
 export interface ItemSchemaProps extends SchemaProps {
   strict?: boolean
 }
 
+/**
+ * Named attributes of an item schema.
+ */
 export interface ItemAttributes {
   [key: string]: Schema
 }

--- a/src/schema/list/errors.ts
+++ b/src/schema/list/errors.ts
@@ -24,6 +24,9 @@ type DefaultedElementsErrorBlueprint = ErrorBlueprint<{
   payload: undefined
 }>
 
+/**
+ * Union of the error blueprints raised when validating a list schema.
+ */
 export type ListSchemaErrorBlueprint =
   | OptionalElementsErrorBlueprint
   | HiddenElementsErrorBlueprint

--- a/src/schema/list/schema.ts
+++ b/src/schema/list/schema.ts
@@ -4,21 +4,33 @@ import type { Schema, SchemaProps } from '../types/index.js'
 import { checkSchemaProps } from '../utils/checkSchemaProps.js'
 import { hasDefinedDefault } from '../utils/hasDefinedDefault.js'
 
+/**
+ * Schema for a list attribute.
+ */
 export class ListSchema<ELEMENTS extends Schema = Schema, PROPS extends SchemaProps = SchemaProps> {
   type: 'list'
   elements: ELEMENTS
   props: PROPS
 
+  /**
+   * Instantiate the schema from its elements and props.
+   */
   constructor(elements: ELEMENTS, props: PROPS) {
     this.type = 'list'
     this.elements = elements
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and elements, then freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/list/types.ts
+++ b/src/schema/list/types.ts
@@ -13,4 +13,7 @@ interface ListElementProps extends SchemaProps {
 }
 
 // TODO: Re-introduce constraint in interface (not only in typer)
+/**
+ * Schema allowed as a list element.
+ */
 export type ListElementSchema = Schema & { props: ListElementProps }

--- a/src/schema/map/errors.ts
+++ b/src/schema/map/errors.ts
@@ -6,4 +6,7 @@ type DuplicateSavedAsErrorBlueprint = ErrorBlueprint<{
   payload: { savedAs: string }
 }>
 
+/**
+ * Error blueprint raised when validating a map schema.
+ */
 export type MapSchemaErrorBlueprint = DuplicateSavedAsErrorBlueprint

--- a/src/schema/map/schema.ts
+++ b/src/schema/map/schema.ts
@@ -5,6 +5,9 @@ import type { SchemaRequiredProp } from '../types/index.js'
 import { checkSchemaProps } from '../utils/checkSchemaProps.js'
 import type { MapAttributes, MapSchemaProps } from './types.js'
 
+/**
+ * Schema for a map attribute.
+ */
 export class MapSchema<
   ATTRIBUTES extends MapAttributes = MapAttributes,
   PROPS extends MapSchemaProps = MapSchemaProps
@@ -17,6 +20,9 @@ export class MapSchema<
   savedAttributeNames: Set<string>
   requiredAttributeNames: Record<SchemaRequiredProp, Set<string>>
 
+  /**
+   * Instantiate the schema from its attributes and props.
+   */
   constructor(attributes: ATTRIBUTES, props: PROPS) {
     this.type = 'map'
     this.attributes = attributes
@@ -41,10 +47,16 @@ export class MapSchema<
     }
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and attributes, then freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/map/types.ts
+++ b/src/schema/map/types.ts
@@ -1,9 +1,15 @@
 import type { Schema, SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by a map schema.
+ */
 export interface MapSchemaProps extends SchemaProps {
   strict?: boolean
 }
 
+/**
+ * Named attributes of a map schema.
+ */
 export interface MapAttributes {
   [key: string]: Schema
 }

--- a/src/schema/null/resolve.ts
+++ b/src/schema/null/resolve.ts
@@ -1,1 +1,4 @@
+/**
+ * Runtime type of a null schema (`null`).
+ */
 export type ResolvedNullSchema = null

--- a/src/schema/null/schema.ts
+++ b/src/schema/null/schema.ts
@@ -1,19 +1,31 @@
 import { checkPrimitiveSchema } from '../primitive/check.js'
 import type { NullSchemaProps } from './types.js'
 
+/**
+ * Schema for a null attribute.
+ */
 export class NullSchema<PROPS extends NullSchemaProps = NullSchemaProps> {
   type: 'null'
   props: PROPS
 
+  /**
+   * Instantiate the schema from its props.
+   */
   constructor(props: PROPS) {
     this.type = 'null'
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/null/types.ts
+++ b/src/schema/null/types.ts
@@ -1,5 +1,8 @@
 import type { SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by a null schema.
+ */
 export interface NullSchemaProps extends SchemaProps {
   enum?: null[]
   transform?: unknown

--- a/src/schema/number/resolve.ts
+++ b/src/schema/number/resolve.ts
@@ -1,5 +1,8 @@
 import type { NumberSchema } from './schema.js'
 
+/**
+ * Resolves a number schema to its runtime type.
+ */
 export type ResolveNumberSchema<SCHEMA extends NumberSchema> = SCHEMA['props']['enum'] extends (
   | number
   | bigint
@@ -9,4 +12,7 @@ export type ResolveNumberSchema<SCHEMA extends NumberSchema> = SCHEMA['props']['
 
 type WithBigInt<BIG extends boolean | undefined> = BIG extends true ? bigint : never
 
+/**
+ * Runtime type of a number schema (`number`).
+ */
 export type ResolvedNumberSchema = ResolveNumberSchema<NumberSchema>

--- a/src/schema/number/schema.ts
+++ b/src/schema/number/schema.ts
@@ -4,19 +4,31 @@ import { isBoolean } from '~/utils/validation/isBoolean.js'
 import { checkPrimitiveSchema } from '../primitive/check.js'
 import type { NumberSchemaProps } from './types.js'
 
+/**
+ * Schema for a number attribute.
+ */
 export class NumberSchema<PROPS extends NumberSchemaProps = NumberSchemaProps> {
   type: 'number'
   props: PROPS
 
+  /**
+   * Instantiate the schema from its props.
+   */
   constructor(props: PROPS) {
     this.type = 'number'
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/number/types.ts
+++ b/src/schema/number/types.ts
@@ -1,5 +1,8 @@
 import type { SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by a number schema.
+ */
 export interface NumberSchemaProps extends SchemaProps {
   big?: boolean
   enum?: (number | bigint)[]

--- a/src/schema/primitive/check.ts
+++ b/src/schema/primitive/check.ts
@@ -5,6 +5,9 @@ import { isValidPrimitive } from '~/utils/validation/isValidPrimitive.js'
 import { checkSchemaProps } from '../utils/checkSchemaProps.js'
 import type { PrimitiveSchema } from './types.js'
 
+/**
+ * Validate the props of a primitive schema: enum value types, and static default value types and enum membership. Throws a `DynamoDBToolboxError` on the first invalid prop.
+ */
 export const checkPrimitiveSchema = (schema: PrimitiveSchema, path?: string): void => {
   checkSchemaProps(schema.props, path)
 

--- a/src/schema/primitive/errors.ts
+++ b/src/schema/primitive/errors.ts
@@ -36,6 +36,9 @@ type InvalidDefaultValueRangeErrorBlueprint = ErrorBlueprint<{
   }
 }>
 
+/**
+ * Union of the error blueprints raised when validating a primitive schema's enum and default props.
+ */
 export type PrimitiveSchemaErrorBlueprint =
   | InvalidEnumValueTypeErrorBlueprint
   | InvalidDefaultValueTypeErrorBlueprint

--- a/src/schema/primitive/types.ts
+++ b/src/schema/primitive/types.ts
@@ -24,6 +24,9 @@ import type {
   StringSchema_
 } from '../string/index.js'
 
+/**
+ * Union of the primitive (non-collection) schema classes: `null`, `boolean`, `number`, `string` and `binary`.
+ */
 export type PrimitiveSchema =
   | NullSchema
   | BooleanSchema
@@ -31,6 +34,9 @@ export type PrimitiveSchema =
   | StringSchema
   | BinarySchema
 
+/**
+ * Union of the builder primitive schema classes.
+ */
 export type PrimitiveSchema_ =
   | NullSchema_
   | BooleanSchema_
@@ -38,6 +44,9 @@ export type PrimitiveSchema_ =
   | StringSchema_
   | BinarySchema_
 
+/**
+ * Runtime type of an unconstrained primitive schema — the union of every primitive's resolved type.
+ */
 export type ResolvedPrimitiveSchema =
   | ResolvedNullSchema
   | ResolvedBooleanSchema
@@ -45,6 +54,9 @@ export type ResolvedPrimitiveSchema =
   | ResolvedStringSchema
   | ResolvedBinarySchema
 
+/**
+ * Resolves a primitive schema to its runtime type by dispatching to the matching per-type resolver.
+ */
 export type ResolvePrimitiveSchema<SCHEMA extends PrimitiveSchema> = PrimitiveSchema extends SCHEMA
   ? ResolvedPrimitiveSchema
   :

--- a/src/schema/record/errors.ts
+++ b/src/schema/record/errors.ts
@@ -66,6 +66,9 @@ type DefaultedElementsErrorBlueprint = ErrorBlueprint<{
   payload: undefined
 }>
 
+/**
+ * Union of the error blueprints raised when validating a record schema.
+ */
 export type RecordSchemaErrorBlueprint =
   | InvalidKeysErrorBlueprint
   | OptionalKeysErrorBlueprint

--- a/src/schema/record/schema.ts
+++ b/src/schema/record/schema.ts
@@ -7,6 +7,9 @@ import { checkSchemaProps } from '../utils/checkSchemaProps.js'
 import { hasDefinedDefault } from '../utils/hasDefinedDefault.js'
 import type { RecordSchemaProps } from './types.js'
 
+/**
+ * Schema for a record attribute.
+ */
 export class RecordSchema<
   KEYS extends StringSchema = StringSchema,
   ELEMENTS extends Schema = Schema,
@@ -17,6 +20,9 @@ export class RecordSchema<
   elements: ELEMENTS
   props: PROPS
 
+  /**
+   * Instantiate the schema from its keys, elements and props.
+   */
   constructor(keys: KEYS, elements: ELEMENTS, props: PROPS) {
     this.type = 'record'
     this.keys = keys
@@ -24,10 +30,16 @@ export class RecordSchema<
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props, keys and elements, then freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/record/types.ts
+++ b/src/schema/record/types.ts
@@ -1,6 +1,9 @@
 import type { StringSchema, StringSchemaProps } from '../string/index.js'
 import type { AtLeastOnce, Schema, SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by a record schema.
+ */
 export interface RecordSchemaProps extends SchemaProps {
   partial?: boolean
 }
@@ -19,7 +22,13 @@ interface RecordKeyAndElementProps extends SchemaProps {
 }
 
 // TODO: Re-introduce constraint in interface (not only in typer)
+/**
+ * Schema allowed as a record element.
+ */
 export type RecordElementSchema = Schema & { props: RecordKeyAndElementProps }
 
 // TODO: Re-introduce constraint in interface (not only in typer)
+/**
+ * Schema allowed as a record key.
+ */
 export type RecordKeySchema = StringSchema<StringSchemaProps & RecordKeyAndElementProps>

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -1,7 +1,13 @@
 import type { Schema } from '~/schema/index.js'
 
+/**
+ * Base class shared by all schema actions.
+ */
 export class SchemaAction<SCHEMA extends Schema = Schema> {
   static actionName: string
 
+  /**
+   * Bind the action to a schema.
+   */
   constructor(readonly schema: SCHEMA) {}
 }

--- a/src/schema/set/errors.ts
+++ b/src/schema/set/errors.ts
@@ -24,6 +24,9 @@ type DefaultedElementsErrorBlueprint = ErrorBlueprint<{
   payload: undefined
 }>
 
+/**
+ * Union of the error blueprints raised when validating a set schema.
+ */
 export type SetSchemaErrorBlueprint =
   | OptionalElementsErrorBlueprint
   | HiddenElementsErrorBlueprint

--- a/src/schema/set/schema.ts
+++ b/src/schema/set/schema.ts
@@ -5,6 +5,9 @@ import { checkSchemaProps } from '../utils/checkSchemaProps.js'
 import { hasDefinedDefault } from '../utils/hasDefinedDefault.js'
 import type { SetElementSchema } from './types.js'
 
+/**
+ * Schema for a set attribute.
+ */
 export class SetSchema<
   ELEMENTS extends SetElementSchema = SetElementSchema,
   PROPS extends SchemaProps = SchemaProps
@@ -13,16 +16,25 @@ export class SetSchema<
   elements: ELEMENTS
   props: PROPS
 
+  /**
+   * Instantiate the schema from its elements and props.
+   */
   constructor(elements: ELEMENTS, props: PROPS) {
     this.type = 'set'
     this.elements = elements
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and elements, then freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/set/types.ts
+++ b/src/schema/set/types.ts
@@ -6,6 +6,9 @@ import type { StringSchema } from '../string/index.js'
 import type { StringSchemaProps } from '../string/types.js'
 import type { AtLeastOnce } from '../types/index.js'
 
+/**
+ * Props enforced on a set's element schema.
+ */
 export interface SetElementProps {
   required?: AtLeastOnce
   hidden?: false
@@ -19,6 +22,9 @@ export interface SetElementProps {
   updateLink?: undefined
 }
 
+/**
+ * Schema allowed as a set element (number, string or binary).
+ */
 export type SetElementSchema =
   | NumberSchema<NumberSchemaProps & SetElementProps>
   | StringSchema<StringSchemaProps & SetElementProps>

--- a/src/schema/string/resolve.ts
+++ b/src/schema/string/resolve.ts
@@ -1,9 +1,15 @@
 import type { StringSchema } from './schema.js'
 
+/**
+ * Resolves a string schema to its runtime type.
+ */
 export type ResolveStringSchema<SCHEMA extends StringSchema> = SCHEMA['props'] extends {
   enum: string[]
 }
   ? SCHEMA['props']['enum'][number]
   : string
 
+/**
+ * Runtime type of a string schema (`string`).
+ */
 export type ResolvedStringSchema = ResolveStringSchema<StringSchema>

--- a/src/schema/string/schema.ts
+++ b/src/schema/string/schema.ts
@@ -1,19 +1,31 @@
 import { checkPrimitiveSchema } from '../primitive/check.js'
 import type { StringSchemaProps } from './types.js'
 
+/**
+ * Schema for a string attribute.
+ */
 export class StringSchema<PROPS extends StringSchemaProps = StringSchemaProps> {
   type: 'string'
   props: PROPS
 
+  /**
+   * Instantiate the schema from its props.
+   */
   constructor(props: PROPS) {
     this.type = 'string'
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/string/types.ts
+++ b/src/schema/string/types.ts
@@ -1,5 +1,8 @@
 import type { SchemaProps } from '../types/index.js'
 
+/**
+ * Props accepted by a string schema.
+ */
 export interface StringSchemaProps extends SchemaProps {
   enum?: string[]
   transform?: unknown

--- a/src/schema/tuple/errors.ts
+++ b/src/schema/tuple/errors.ts
@@ -30,6 +30,9 @@ type SavedAsElementsErrorBlueprint = ErrorBlueprint<{
   payload: undefined
 }>
 
+/**
+ * Union of the error blueprints raised when validating a tuple schema.
+ */
 export type TupleSchemaErrorBlueprint =
   | InvalidElementsErrorBlueprint
   | MissingElementsErrorBlueprint

--- a/src/schema/tuple/schema.ts
+++ b/src/schema/tuple/schema.ts
@@ -5,6 +5,9 @@ import type { SchemaProps } from '../types/index.js'
 import { checkSchemaProps } from '../utils/checkSchemaProps.js'
 import type { TupleElementSchema } from './types.js'
 
+/**
+ * Schema for a tuple attribute.
+ */
 export class TupleSchema<
   ELEMENTS extends TupleElementSchema[] = TupleElementSchema[],
   PROPS extends SchemaProps = SchemaProps
@@ -13,16 +16,25 @@ export class TupleSchema<
   elements: ELEMENTS
   props: PROPS
 
+  /**
+   * Instantiate the schema from its elements and props.
+   */
   constructor(elements: ELEMENTS, props: PROPS) {
     this.type = 'tuple'
     this.elements = elements
     this.props = props
   }
 
+  /**
+   * Whether the schema's props have been validated and frozen.
+   */
   get checked(): boolean {
     return Object.isFrozen(this.props)
   }
 
+  /**
+   * Validate the schema's props and elements, then freeze them.
+   */
   check(path?: string): void {
     if (this.checked) {
       return

--- a/src/schema/tuple/types.ts
+++ b/src/schema/tuple/types.ts
@@ -6,4 +6,7 @@ interface TupleElementProps extends SchemaProps {
   savedAs?: undefined
 }
 
+/**
+ * Schema allowed as a tuple element.
+ */
 export type TupleElementSchema = Schema & { props: TupleElementProps }

--- a/src/schema/types/attribute.ts
+++ b/src/schema/types/attribute.ts
@@ -5,11 +5,17 @@ import type { ResolvedNumberSchema } from '../number/index.js'
 import type { ResolvedStringSchema } from '../string/index.js'
 import type { Schema } from './schema.js'
 
+/**
+ * A custom value type injected into schemas by an extension parser.
+ */
 export type Extension = {
   type: Schema['type'] | '*'
   value: unknown
 }
 
+/**
+ * Extension values matching a given schema type.
+ */
 export type ExtendedValue<
   EXTENSIONS extends Extension,
   TYPE extends Schema['type'] | '*'
@@ -25,71 +31,140 @@ export type ExtendedValue<
       : never
     : never
 
+/**
+ * Runtime value of a null schema, without extensions.
+ */
 export type NullUnextendedValue = ResolvedNullSchema
+/**
+ * Runtime value of a null schema, including extensions.
+ */
 export type NullExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'null'>
   | NullUnextendedValue
 
+/**
+ * Runtime value of a boolean schema, without extensions.
+ */
 export type BooleanUnextendedValue = ResolvedBooleanSchema
+/**
+ * Runtime value of a boolean schema, including extensions.
+ */
 export type BooleanExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'boolean'>
   | BooleanUnextendedValue
 
+/**
+ * Runtime value of a number schema, without extensions.
+ */
 export type NumberUnextendedValue = ResolvedNumberSchema
+/**
+ * Runtime value of a number schema, including extensions.
+ */
 export type NumberExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'number'>
   | NumberUnextendedValue
 
+/**
+ * Runtime value of a string schema, without extensions.
+ */
 export type StringUnextendedValue = ResolvedStringSchema
+/**
+ * Runtime value of a string schema, including extensions.
+ */
 export type StringExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'string'>
   | StringUnextendedValue
 
+/**
+ * Runtime value of a binary schema, without extensions.
+ */
 export type BinaryUnextendedValue = ResolvedBinarySchema
+/**
+ * Runtime value of a binary schema, including extensions.
+ */
 export type BinaryExtendedAttributeValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'binary'>
   | BinaryUnextendedValue
 
+/**
+ * Runtime value of a set schema, without extensions.
+ */
 export type SetUnextendedValue<EXTENSION extends Extension = never> = Set<
   SchemaExtendedValue<EXTENSION>
 >
+/**
+ * Runtime value of a set schema, including extensions.
+ */
 export type SetExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'set'>
   | SetUnextendedValue<EXTENSION>
 
+/**
+ * Runtime value of a list schema, without extensions.
+ */
 export type ListUnextendedValue<EXTENSION extends Extension = never> =
   SchemaExtendedValue<EXTENSION>[]
+/**
+ * Runtime value of a list schema, including extensions.
+ */
 export type ListExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'list'>
   | ListUnextendedValue<EXTENSION>
 
+/**
+ * Runtime value of a tuple schema, without extensions.
+ */
 export type TupleUnextendedValue<EXTENSION extends Extension = never> =
   SchemaExtendedValue<EXTENSION>[]
+/**
+ * Runtime value of a tuple schema, including extensions.
+ */
 export type TupleExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'tuple'>
   | TupleUnextendedValue<EXTENSION>
 
+/**
+ * Runtime value of a map schema, without extensions.
+ */
 export type MapUnextendedValue<EXTENSION extends Extension = never> = {
   [key: string]: SchemaExtendedValue<EXTENSION>
 }
+/**
+ * Runtime value of a map schema, including extensions.
+ */
 export type MapExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'map'>
   | MapUnextendedValue<EXTENSION>
 
+/**
+ * Runtime value of a record schema, without extensions.
+ */
 export type RecordUnextendedValue<EXTENSION extends Extension = never> = {
   [key: string]: SchemaExtendedValue<EXTENSION> | undefined
 }
+/**
+ * Runtime value of a record schema, including extensions.
+ */
 export type RecordExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'record'>
   | RecordUnextendedValue<EXTENSION>
 
+/**
+ * Runtime value of an item schema, without extensions.
+ */
 export type ItemUnextendedValue<EXTENSION extends Extension = never> = {
   [key: string]: SchemaExtendedValue<EXTENSION> | undefined
 }
+/**
+ * Runtime value of an item schema, including extensions.
+ */
 export type ItemExtendedValue<EXTENSION extends Extension = never> =
   | ExtendedValue<EXTENSION, 'item'>
   | ItemUnextendedValue<EXTENSION>
 
+/**
+ * Runtime value of any schema, without extensions.
+ */
 export type SchemaUnextendedValue<EXTENSION extends Extension = never> =
   | NullUnextendedValue
   | BooleanUnextendedValue
@@ -103,6 +178,9 @@ export type SchemaUnextendedValue<EXTENSION extends Extension = never> =
   | RecordUnextendedValue<EXTENSION>
   | ItemUnextendedValue<EXTENSION>
 
+/**
+ * Runtime value of any schema, including extensions.
+ */
 export type SchemaExtendedValue<EXTENSION extends Extension = never> =
   | NullExtendedValue<EXTENSION>
   | BooleanExtendedValue<EXTENSION>

--- a/src/schema/types/extensionParser.ts
+++ b/src/schema/types/extensionParser.ts
@@ -5,13 +5,21 @@ import type { TransformedValue } from './transformedValue.js'
 import type { ValidValue } from './validValue.js'
 
 export const $extension = Symbol('$extension')
+/** Key branding an extension parser with its extension type. */
 export type $extension = typeof $extension
 
 export const $contextExtension = Symbol('$contextExtension')
+/** Key branding an extension parser with its context extension type. */
 export type $contextExtension = typeof $contextExtension
 
+/**
+ * Options accepted by an extension parser.
+ */
 export type ExtensionParserOptions = { transform?: boolean; valuePath?: ArrayPath }
 
+/**
+ * Function that parses extension values within a schema.
+ */
 export type ExtensionParser<
   EXTENSION extends Extension = Extension,
   CONTEXT_EXTENSION extends Extension = EXTENSION

--- a/src/schema/types/formattedValue.ts
+++ b/src/schema/types/formattedValue.ts
@@ -27,6 +27,9 @@ import type { ReadValueOptions } from './options.js'
 import type { ChildPaths, ElementPaths, MatchIndexes, MatchKeys } from './pathUtils.js'
 import type { Paths } from './paths.js'
 
+/**
+ * App-facing value of a schema after reads are projected and formatted.
+ */
 export type FormattedValue<
   SCHEMA extends Schema,
   OPTIONS extends ReadValueOptions<SCHEMA> = {}

--- a/src/schema/types/inputValue.ts
+++ b/src/schema/types/inputValue.ts
@@ -20,6 +20,9 @@ import type { Extends, If, Not, Optional, Overwrite, SelectKeys } from '~/types/
 
 import type { SchemaExtendedWriteValue, WriteValueOptions } from './options.js'
 
+/**
+ * Value accepted as input when writing a schema (before defaults and links).
+ */
 export type InputValue<
   SCHEMA extends Schema,
   OPTIONS extends WriteValueOptions = {}
@@ -29,6 +32,9 @@ export type InputValue<
     ? SchemaInputValue<SCHEMA, OPTIONS>
     : never
 
+/**
+ * Input values of a tuple of schemas.
+ */
 export type InputValueRec<
   SCHEMAS extends Schema[],
   OPTIONS extends WriteValueOptions = {},

--- a/src/schema/types/options.ts
+++ b/src/schema/types/options.ts
@@ -1,13 +1,22 @@
 import type { ExtendedValue, Extension, Paths, Schema } from '~/schema/index.js'
 
+/**
+ * Write context of a value: `key`, `put` or `update`.
+ */
 export type WriteMode = 'key' | 'put' | 'update'
 
+/**
+ * Options controlling how a value is parsed for writes.
+ */
 export interface WriteValueOptions {
   mode?: WriteMode
   extension?: Extension
   defined?: boolean
 }
 
+/**
+ * Extension value allowed when writing a schema.
+ */
 export type SchemaExtendedWriteValue<
   SCHEMA extends Schema,
   OPTIONS extends WriteValueOptions = {}
@@ -15,6 +24,9 @@ export type SchemaExtendedWriteValue<
   ? ExtendedValue<OPTIONS['extension'], SCHEMA['type']>
   : never
 
+/**
+ * Options controlling how a value is formatted for reads.
+ */
 export type ReadValueOptions<SCHEMA extends Schema> = {
   attributes?: Paths<SCHEMA>
   partial?: boolean

--- a/src/schema/types/pathUtils.ts
+++ b/src/schema/types/pathUtils.ts
@@ -33,6 +33,11 @@ export type MatchIndexes<
     >
   : MATCHING_INDEXES
 
+/**
+ * Sub-paths of an attribute key within a set of paths.
+ *
+ * @example ChildPaths<"foo", ".foo.bar" | ".foo[0]" | ".baz"> => ".bar" | "[0]"
+ */
 export type ChildPaths<
   KEY extends string,
   PATHS extends string,
@@ -45,6 +50,11 @@ export type ChildPaths<
       ? CHILD_PATHS
       : never
 
+/**
+ * Sub-paths of an element index within a set of paths.
+ *
+ * @example ElementPaths<"[0].foo" | "[0][1]" | "[2].bar", 0> => ".foo" | "[1]"
+ */
 export type ElementPaths<
   PATHS extends string,
   INDEX extends number = number

--- a/src/schema/types/paths.ts
+++ b/src/schema/types/paths.ts
@@ -11,13 +11,26 @@ import type {
 } from '~/schema/index.js'
 import type { Extends, If } from '~/types/index.js'
 
+/**
+ * Characters that must be escaped within a path segment.
+ */
 export type CharsToEscape = '[' | ']' | '.'
+
+/**
+ * A string containing a character that must be escaped.
+ */
 export type StringToEscape = `${string}${CharsToEscape}${string}`
 
+/**
+ * Appends a key to a path, escaping it when needed.
+ */
 export type AppendKey<PATH extends string, KEY extends string> =
-  | `${PATH}['${KEY}']`
   | If<Extends<KEY, StringToEscape>, never, `${PATH}.${KEY}`>
+  | `${PATH}['${KEY}']`
 
+/**
+ * Union of every valid attribute path of a schema.
+ */
 // string is there to simplify type-constraint checks when using Paths
 export type Paths<SCHEMA extends Schema = Schema> = string &
   (SCHEMA extends ItemSchema
@@ -26,6 +39,9 @@ export type Paths<SCHEMA extends Schema = Schema> = string &
       ? SchemaPaths<SCHEMA>
       : never)
 
+/**
+ * Union of the paths of a non-item schema.
+ */
 export type SchemaPaths<SCHEMA extends Schema, SCHEMA_PATH extends string = ''> =
   | (SCHEMA extends AnySchema ? AnySchemaPaths<SCHEMA_PATH> : never)
   | (SCHEMA extends ListSchema ? ListSchemaPaths<SCHEMA, SCHEMA_PATH> : never)
@@ -34,6 +50,9 @@ export type SchemaPaths<SCHEMA extends Schema, SCHEMA_PATH extends string = ''> 
   | (SCHEMA extends RecordSchema ? RecordSchemaPaths<SCHEMA, SCHEMA_PATH> : never)
   | (SCHEMA extends AnyOfSchema ? AnyOfSchemaPaths<SCHEMA, SCHEMA_PATH> : never)
 
+/**
+ * Union of the paths of an item schema.
+ */
 export type ItemSchemaPaths<SCHEMA extends ItemSchema = ItemSchema> = ItemSchema extends SCHEMA
   ? string
   : keyof SCHEMA['attributes'] extends infer SCHEMA_PATH

--- a/src/schema/types/schema.ts
+++ b/src/schema/types/schema.ts
@@ -8,6 +8,9 @@ import type { RecordSchema, RecordSchema_ } from '../record/index.js'
 import type { SetSchema, SetSchema_ } from '../set/index.js'
 import type { TupleSchema, TupleSchema_ } from '../tuple/index.js'
 
+/**
+ * Union of every resolved schema type.
+ */
 export type Schema =
   | AnySchema
   | PrimitiveSchema
@@ -19,6 +22,9 @@ export type Schema =
   | AnyOfSchema
   | ItemSchema
 
+/**
+ * Union of every builder (warm) schema type.
+ */
 export type Schema_ =
   | AnySchema_
   | PrimitiveSchema_

--- a/src/schema/types/schemaProps.ts
+++ b/src/schema/types/schemaProps.ts
@@ -30,6 +30,9 @@ export interface SchemaMeta {
   [key: string]: unknown
 }
 
+/**
+ * Common props shared by every schema.
+ */
 export interface SchemaProps {
   required?: SchemaRequiredProp
   hidden?: boolean

--- a/src/schema/types/transformedValue.ts
+++ b/src/schema/types/transformedValue.ts
@@ -43,6 +43,9 @@ export type TransformedValue<
     ? SchemaTransformedValue<SCHEMA, OPTIONS>
     : never
 
+/**
+ * Transformed values of a tuple of schemas.
+ */
 export type TransformedValueRec<
   SCHEMAS extends Schema[],
   OPTIONS extends WriteValueOptions = {},

--- a/src/schema/types/validValue.ts
+++ b/src/schema/types/validValue.ts
@@ -19,6 +19,9 @@ import type { Extends, If, Not, Optional, Overwrite, SelectKeys } from '~/types/
 
 import type { SchemaExtendedWriteValue, WriteValueOptions } from './options.js'
 
+/**
+ * Value of a schema after validation, defaults and links are applied.
+ */
 export type ValidValue<
   SCHEMA extends Schema,
   OPTIONS extends WriteValueOptions = {}
@@ -28,6 +31,9 @@ export type ValidValue<
     ? SchemaValidValue<SCHEMA, OPTIONS>
     : never
 
+/**
+ * Valid values of a tuple of schemas.
+ */
 export type ValidValueRec<
   SCHEMAS extends Schema[],
   OPTIONS extends WriteValueOptions = {},

--- a/src/schema/types/validator.ts
+++ b/src/schema/types/validator.ts
@@ -1,3 +1,6 @@
+/**
+ * Custom validation function for a schema value.
+ */
 export type Validator<INPUT = unknown, SCHEMA = unknown> = (
   input: INPUT,
   schema: SCHEMA

--- a/src/schema/utils/errors.ts
+++ b/src/schema/utils/errors.ts
@@ -10,4 +10,7 @@ type InvalidPropErrorBlueprint = ErrorBlueprint<{
   }
 }>
 
+/**
+ * Error blueprint raised when validating any schema prop.
+ */
 export type SharedSchemaErrorBlueprint = InvalidPropErrorBlueprint

--- a/src/schema/utils/hasDefinedDefault.ts
+++ b/src/schema/utils/hasDefinedDefault.ts
@@ -1,5 +1,8 @@
 import type { Schema } from '../types/index.js'
 
+/**
+ * Whether a schema declares a default or link value.
+ */
 export const hasDefinedDefault = (schema: Schema): boolean =>
   (['keyDefault', 'putDefault', 'updateDefault', 'keyLink', 'putLink', 'updateLink'] as const).some(
     prop => schema.props[prop] !== undefined

--- a/src/schema/utils/isDynamicDefault.ts
+++ b/src/schema/utils/isDynamicDefault.ts
@@ -1,6 +1,9 @@
 import type { SchemaExtendedValue } from '~/schema/index.js'
 import { isFunction } from '~/utils/validation/isFunction.js'
 
+/**
+ * Whether a default value is a function computed at runtime.
+ */
 export const isDynamicDefault = (
   defaultValue: unknown
 ): defaultValue is (input?: unknown) => SchemaExtendedValue => isFunction(defaultValue)

--- a/src/schema/utils/isKeyAttribute.ts
+++ b/src/schema/utils/isKeyAttribute.ts
@@ -1,3 +1,6 @@
 import type { Schema } from '~/schema/index.js'
 
+/**
+ * Whether a schema is part of the primary key.
+ */
 export const isKeyAttribute = (schema: Schema): boolean => !!schema.props.key

--- a/src/schema/utils/isStaticDefault.ts
+++ b/src/schema/utils/isStaticDefault.ts
@@ -2,5 +2,8 @@ import type { SchemaExtendedValue } from '~/schema/index.js'
 
 import { isDynamicDefault } from './isDynamicDefault.js'
 
+/**
+ * Whether a default value is a static (non-function) value.
+ */
 export const isStaticDefault = (defaultValue: unknown): defaultValue is SchemaExtendedValue =>
   !isDynamicDefault(defaultValue)

--- a/src/schema/utils/light.ts
+++ b/src/schema/utils/light.ts
@@ -14,8 +14,12 @@ import type { StringSchema } from '../string/index.js'
 import type { TupleSchema } from '../tuple/index.js'
 import type { Schema } from '../types/index.js'
 
+/**
+ * Schema type stripped of its builder methods to speed up type computes.
+ */
 // Required to support big schemas: We "strip" schema methods when calling a typer to avoid type computes (.required, .hidden etc.)
 // NOTE: We don't need to be recursive as every typer lightens its output
+// TODO: De-nestify
 export type Light<SCHEMA extends Schema> = SCHEMA extends AnySchema
   ? AnySchema<SCHEMA['props']>
   : SCHEMA extends NullSchema
@@ -44,9 +48,15 @@ export type Light<SCHEMA extends Schema> = SCHEMA extends AnySchema
 
 type Lightener = <SCHEMA extends Schema>(schema: SCHEMA) => Light<SCHEMA>
 
+/**
+ * Strip a schema's builder methods to speed up type computes.
+ */
 export const light: Lightener = <SCHEMA extends Schema>(schema: SCHEMA) =>
   schema as unknown as Light<SCHEMA>
 
+/**
+ * Lightened types of a tuple of schemas.
+ */
 export type LightRec<SCHEMAS extends Schema[], RESULTS extends Schema[] = []> = SCHEMAS extends [
   infer SCHEMAS_HEAD extends Schema,
   ...infer SCHEMAS_TAIL extends Schema[]
@@ -56,9 +66,15 @@ export type LightRec<SCHEMAS extends Schema[], RESULTS extends Schema[] = []> = 
 
 type LightenerRec = <SCHEMAS extends Schema[]>(...schemas: SCHEMAS) => LightRec<SCHEMAS>
 
+/**
+ * Strip the builder methods of a tuple of schemas.
+ */
 export const lightRec: LightenerRec = <SCHEMAS extends Schema[]>(...schemas: SCHEMAS) =>
   schemas as unknown as LightRec<SCHEMAS>
 
+/**
+ * Lightened types of a record of schemas.
+ */
 export type LightObj<SCHEMAS extends { [KEY in string]: Schema }> = ComputeObject<{
   [KEY in keyof SCHEMAS]: Light<SCHEMAS[KEY]>
 }>
@@ -67,6 +83,9 @@ type LightenerObj = <SCHEMAS extends { [KEY in string]: Schema }>(
   schemas: SCHEMAS
 ) => LightObj<SCHEMAS>
 
+/**
+ * Strip the builder methods of a record of schemas.
+ */
 export const lightObj: LightenerObj = <SCHEMAS extends { [KEY in string]: Schema }>(
   schemas: SCHEMAS
 ) => schemas as unknown as LightObj<SCHEMAS>

--- a/src/schema/utils/resetLinks.ts
+++ b/src/schema/utils/resetLinks.ts
@@ -14,6 +14,9 @@ import type {
   StringSchema
 } from '~/schema/index.js'
 
+/**
+ * Schema type with its link props removed.
+ */
 export type ResetLinks<SCHEMA extends Schema> =
   | (SCHEMA extends AnySchema
       ? AnySchema<{
@@ -122,6 +125,9 @@ export type ResetLinks<SCHEMA extends Schema> =
 
 type LinksResetter = <SCHEMA extends Schema>(schema: SCHEMA) => ResetLinks<SCHEMA>
 
+/**
+ * Clone a schema with its link props cleared.
+ */
 export const resetLinks: LinksResetter = schema =>
   (schema as Schema_)
     // @ts-expect-error Signatures don't match but we don't care


### PR DESCRIPTION
## What

Adds [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc) and enables a **presence-only** `jsdoc/require-jsdoc` rule, then documents the entire `src/schema` tree so the rule can be turned on there.

The rule only checks that a `/** ... */` block **exists** on public API — it validates no content (no param/return/description rules). A single short sentence is enough.

## How it's scoped

- Root rule stays `off`.
- A `src/schema/**/*.ts` override flips it to `error` with the full options:
  - `publicOnly.esm: true` — only exports reachable from the barrel are flagged (barrel re-exports and non-exported `type X` are never flagged).
  - `exemptEmptyConstructors: true`.
  - `require`: functions (decl/expr/arrow) + classes.
  - `contexts`: public `MethodDefinition` + `TSTypeAliasDeclaration` / `TSInterfaceDeclaration` / `TSEnumDeclaration`.
- The override is placed **before** the existing `**/*.test.ts` override, so schema test files remain exempt.
- `@debt` / `@interceptable` stay whitelisted via `settings.jsdoc.definedTags`; types already carrying a `@debt` block satisfy the rule and were left untouched.

Global promotion to `error` for the rest of the codebase is a separate follow-up task.

## Rollout

Documented folder-by-folder (one commit per group), each verified green before moving on:

- schema type folders (primitive → collection → composite → item)
- schema `types/` + `utils/`
- actions: `parse` / `parsePaths` / `parseCondition`, `format`, `jsonSchemer`, `dto`, `fromDTO`, `finder`, `zodSchemer`, `fromZodSchema`

Style: short single sentence, type/keyword names in backticks (e.g. `` Parse a value against a `set` schema. ``).

Two throwaway cast-only local type aliases the rule flagged (`RESPONSE`, `ZOD_FORMATTER`/`ZOD_PARSER`) were inlined rather than documented as noise — behavior-identical.

## Test plan

- `npm test` (type + format + unit + lint + exports) — green.
- Verified the override resolves per file: schema source → `error`, schema test → `off`, non-schema → `off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)