### PR TITLE
feat(lint): enforce jsdoc/require-jsdoc for src/transformers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -85,6 +85,32 @@
       }
     },
     {
+      "files": ["src/transformers/**/*.ts"],
+      "rules": {
+        "jsdoc/require-jsdoc": [
+          "error",
+          {
+            "publicOnly": { "esm": true },
+            "enableFixer": false,
+            "exemptEmptyConstructors": true,
+            "require": {
+              "FunctionDeclaration": true,
+              "FunctionExpression": true,
+              "ArrowFunctionExpression": true,
+              "ClassDeclaration": true,
+              "ClassExpression": true
+            },
+            "contexts": [
+              "MethodDefinition:not([accessibility=\"private\"]):not([key.type=\"PrivateIdentifier\"])",
+              "TSTypeAliasDeclaration",
+              "TSInterfaceDeclaration",
+              "TSEnumDeclaration"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["**/*.test.ts"],
       "rules": {
         "@typescript-eslint/no-unused-vars": "off",

--- a/src/transformers/jsonStringify.ts
+++ b/src/transformers/jsonStringify.ts
@@ -10,11 +10,17 @@ interface JSONStringifierOptions {
   reviver?: (this: any, key: string, value: any) => any
 }
 
+/**
+ * DTO describing a `JSONStringifier` transformer.
+ */
 export interface JSONStringifierDTO {
   transformerId: 'jsonStringify'
   space?: string | number
 }
 
+/**
+ * Transformer that encodes values to JSON strings and decodes them back.
+ */
 export class JSONStringifier
   implements
     SerializableTransformer<unknown, unknown, string, Constant<string>, JSONStringifierDTO>
@@ -26,6 +32,9 @@ export class JSONStringifier
   replacer?: (this: any, key: string, value: any) => any
   reviver?: (this: any, key: string, value: any) => any
 
+  /**
+   * Create a `JSONStringifier` with optional `space`, `replacer` and `reviver`.
+   */
   constructor({ space, replacer, reviver }: JSONStringifierOptions = {}) {
     this.transformerId = 'jsonStringify'
     this.space = space
@@ -33,14 +42,23 @@ export class JSONStringifier
     this.reviver = reviver
   }
 
+  /**
+   * Encode the decoded value to a JSON string.
+   */
   encode(decoded: unknown): string {
     return JSON.stringify(decoded, this.replacer, this.space)
   }
 
+  /**
+   * Parse the encoded JSON string back to a value.
+   */
   decode(encoded: string): unknown {
     return JSON.parse(encoded, this.reviver)
   }
 
+  /**
+   * Serialize this transformer to its DTO.
+   */
   toJSON() {
     if (this.replacer !== undefined || this.reviver !== undefined) {
       console.warn(
@@ -54,6 +72,9 @@ export class JSONStringifier
     }
   }
 
+  /**
+   * Chain this transformer with another, applied after it.
+   */
   pipe<TRANSFORMER extends Transformer<string>>(
     transformer: TRANSFORMER
   ): Piped<[this, TRANSFORMER]> {
@@ -63,5 +84,8 @@ export class JSONStringifier
 
 type JSONStringify = (options?: JSONStringifierOptions) => JSONStringifier
 
+/**
+ * Create a `JSONStringifier` transformer that serializes values as JSON.
+ */
 export const jsonStringify: JSONStringify = (options: JSONStringifierOptions = {}) =>
   new JSONStringifier(options)

--- a/src/transformers/pipe.ts
+++ b/src/transformers/pipe.ts
@@ -23,6 +23,9 @@ const composeRight =
 
 const identity: Fn = arg => arg
 
+/**
+ * Transformer that composes a sequence of transformers, encoding left-to-right.
+ */
 export class Pipe<TRANSFORMERS extends Transformer[] = Transformer[]>
   implements
     TypedTransformer<
@@ -46,6 +49,9 @@ export class Pipe<TRANSFORMERS extends Transformer[] = Transformer[]>
     encoded: ReturnType<LastTransformer<TRANSFORMERS>['encode']>
   ) => ReturnType<TRANSFORMERS[0]['decode']>
 
+  /**
+   * Create a `Pipe` composing the given transformers in order.
+   */
   constructor(transformers: TRANSFORMERS) {
     this.transformerId = 'pipe'
     this.transformers = transformers
@@ -59,6 +65,9 @@ export class Pipe<TRANSFORMERS extends Transformer[] = Transformer[]>
       .reduce(composeRight, identity)
   }
 
+  /**
+   * Append another transformer to this pipe, applied after the existing ones.
+   */
   pipe<TRANSFORMER extends Transformer<ReturnType<LastTransformer<TRANSFORMERS>['encode']>>>(
     transformer: TRANSFORMER
   ): Piped<[...TRANSFORMERS, TRANSFORMER]> {
@@ -66,6 +75,9 @@ export class Pipe<TRANSFORMERS extends Transformer[] = Transformer[]>
   }
 }
 
+/**
+ * `Pipe` of serializable transformers that can itself be serialized to a DTO.
+ */
 export class SerializablePipe<
     TRANSFORMERS extends SerializableTransformer[] = SerializableTransformer[]
   >
@@ -79,10 +91,16 @@ export class SerializablePipe<
       PipeDTO<TransformerDTOs<TRANSFORMERS>>
     >
 {
+  /**
+   * Create a `SerializablePipe` composing the given serializable transformers.
+   */
   constructor(transformers: TRANSFORMERS) {
     super(transformers)
   }
 
+  /**
+   * Serialize this pipe and its transformers to a DTO.
+   */
   toJSON() {
     return {
       transformerId: this.transformerId,
@@ -91,6 +109,9 @@ export class SerializablePipe<
   }
 }
 
+/**
+ * DTO describing a `SerializablePipe`, holding its transformers' DTOs.
+ */
 export interface PipeDTO<TRANSFORMER_DTOS extends ITransformerDTO[] = ITransformerDTO[]> {
   transformerId: 'pipe'
   transformers: TRANSFORMER_DTOS
@@ -107,6 +128,9 @@ type LastTransformer<TRANSFORMERS extends Transformer[]> = TRANSFORMERS extends 
     : never
   : TRANSFORMERS[0]
 
+/**
+ * Resolve the pipe type for a tuple of transformers (`SerializablePipe` when all are serializable).
+ */
 export type Piped<TRANSFORMERS extends Transformer[]> =
   TRANSFORMERS extends SerializableTransformer[]
     ? SerializablePipe<TRANSFORMERS>
@@ -116,6 +140,9 @@ type Piper = <TRANSFORMERS extends Transformer[]>(
   ...transformers: TRANSFORMERS
 ) => Piped<TRANSFORMERS>
 
+/**
+ * Compose transformers into a single pipe applied left-to-right on encode.
+ */
 export const pipe: Piper = <TRANSFORMERS extends Transformer[]>(...transformers: TRANSFORMERS) =>
   (transformers.every(isSerializableTransformer)
     ? new SerializablePipe(transformers)

--- a/src/transformers/prefix.ts
+++ b/src/transformers/prefix.ts
@@ -8,12 +8,18 @@ interface PrefixerOptions<DELIMITER extends string> {
   delimiter?: DELIMITER
 }
 
+/**
+ * DTO describing a `Prefixer` transformer.
+ */
 export interface PrefixerDTO {
   transformerId: 'prefix'
   prefix: string
   delimiter: string
 }
 
+/**
+ * Transformer that prepends a prefix (joined by a delimiter) to a string value.
+ */
 export class Prefixer<PREFIX extends string, DELIMITER extends string = '#'>
   implements
     SerializableTransformer<
@@ -30,22 +36,34 @@ export class Prefixer<PREFIX extends string, DELIMITER extends string = '#'>
   prefix: PREFIX
   delimiter: DELIMITER
 
+  /**
+   * Create a `Prefixer` for the given prefix and optional delimiter (defaults to `#`).
+   */
   constructor(prefix: PREFIX, { delimiter = '#' as DELIMITER }: PrefixerOptions<DELIMITER> = {}) {
     this.transformerId = 'prefix'
     this.prefix = prefix
     this.delimiter = delimiter
   }
 
+  /**
+   * Prepend the prefix and delimiter to the decoded string.
+   */
   encode(decoded: string): string {
     return [this.prefix, decoded].join(this.delimiter)
   }
 
+  /**
+   * Strip the prefix and delimiter from an encoded string if present.
+   */
   decode(encoded: string): string {
     return encoded.startsWith(`${this.prefix}${this.delimiter}`)
       ? encoded.slice(this.prefix.length + this.delimiter.length)
       : encoded
   }
 
+  /**
+   * Serialize this transformer to its DTO.
+   */
   toJSON() {
     return {
       transformerId: this.transformerId,
@@ -54,6 +72,9 @@ export class Prefixer<PREFIX extends string, DELIMITER extends string = '#'>
     }
   }
 
+  /**
+   * Chain this transformer with another, applied after it.
+   */
   pipe<TRANSFORMER extends Transformer<string>>(
     transformer: TRANSFORMER
   ): Piped<[this, TRANSFORMER]> {
@@ -66,6 +87,9 @@ type Prefix = <PREFIX extends string, DELIMITER extends string = '#'>(
   options?: PrefixerOptions<DELIMITER>
 ) => Prefixer<PREFIX, DELIMITER>
 
+/**
+ * Create a `Prefixer` transformer that prepends a prefix to a string.
+ */
 export const prefix: Prefix = <PREFIX extends string, DELIMITER extends string = '#'>(
   prefix: PREFIX,
   { delimiter = '#' as DELIMITER }: PrefixerOptions<DELIMITER> = {}

--- a/src/transformers/suffix.ts
+++ b/src/transformers/suffix.ts
@@ -8,12 +8,18 @@ interface SuffixerOptions<DELIMITER extends string> {
   delimiter?: DELIMITER
 }
 
+/**
+ * DTO describing a `Suffixer` transformer.
+ */
 export interface SuffixerDTO {
   transformerId: 'suffix'
   suffix: string
   delimiter: string
 }
 
+/**
+ * Transformer that appends a suffix (joined by a delimiter) to a string value.
+ */
 export class Suffixer<SUFFIX extends string, DELIMITER extends string = '#'>
   implements
     SerializableTransformer<
@@ -30,22 +36,34 @@ export class Suffixer<SUFFIX extends string, DELIMITER extends string = '#'>
   suffix: SUFFIX
   delimiter: DELIMITER
 
+  /**
+   * Create a `Suffixer` for the given suffix and optional delimiter (defaults to `#`).
+   */
   constructor(suffix: SUFFIX, { delimiter = '#' as DELIMITER }: SuffixerOptions<DELIMITER> = {}) {
     this.transformerId = 'suffix'
     this.suffix = suffix
     this.delimiter = delimiter
   }
 
+  /**
+   * Append the delimiter and suffix to the decoded string.
+   */
   encode(decoded: string): string {
     return [decoded, this.suffix].join(this.delimiter)
   }
 
+  /**
+   * Strip the delimiter and suffix from an encoded string if present.
+   */
   decode(encoded: string): string {
     return encoded.endsWith(`${this.delimiter}${this.suffix}`)
       ? encoded.slice(0, encoded.length - this.delimiter.length - this.suffix.length)
       : encoded
   }
 
+  /**
+   * Serialize this transformer to its DTO.
+   */
   toJSON() {
     return {
       transformerId: this.transformerId,
@@ -54,6 +72,9 @@ export class Suffixer<SUFFIX extends string, DELIMITER extends string = '#'>
     }
   }
 
+  /**
+   * Chain this transformer with another, applied after it.
+   */
   pipe<TRANSFORMER extends Transformer<string>>(
     transformer: TRANSFORMER
   ): Piped<[this, TRANSFORMER]> {
@@ -66,6 +87,9 @@ type Suffix = <SUFFIX extends string, DELIMITER extends string = '#'>(
   options?: SuffixerOptions<DELIMITER>
 ) => Suffixer<SUFFIX, DELIMITER>
 
+/**
+ * Create a `Suffixer` transformer that appends a suffix to a string.
+ */
 export const suffix: Suffix = <SUFFIX extends string, DELIMITER extends string = '#'>(
   suffix: SUFFIX,
   { delimiter = '#' as DELIMITER }: SuffixerOptions<DELIMITER> = {}

--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -1,5 +1,8 @@
 import type { Fn } from 'hotscript'
 
+/**
+ * Reversible codec that encodes a decoded value toward DynamoDB and decodes it back.
+ */
 export interface Transformer<
   DECODED_CONSTRAINT = any,
   DECODED extends DECODED_CONSTRAINT = DECODED_CONSTRAINT,
@@ -9,6 +12,9 @@ export interface Transformer<
   decode: (encoded: ENCODED) => DECODED_CONSTRAINT
 }
 
+/**
+ * `Transformer` that also carries a type-level modifier describing its encoding.
+ */
 export interface TypedTransformer<
   DECODED_CONSTRAINT = any,
   DECODED extends DECODED_CONSTRAINT = DECODED_CONSTRAINT,
@@ -18,8 +24,14 @@ export interface TypedTransformer<
   _typeModifier: TYPE_MODIFIER
 }
 
+/**
+ * Base shape of a transformer DTO, identified by its `transformerId`.
+ */
 export type ITransformerDTO = { transformerId: string } & object
 
+/**
+ * `TypedTransformer` that can be serialized to and from a DTO.
+ */
 export interface SerializableTransformer<
   DECODED_CONSTRAINT = any,
   DECODED extends DECODED_CONSTRAINT = DECODED_CONSTRAINT,

--- a/src/transformers/trim.ts
+++ b/src/transformers/trim.ts
@@ -4,10 +4,16 @@ import type { Piped } from './pipe.js'
 import { pipe } from './pipe.js'
 import type { SerializableTransformer, Transformer } from './transformer.js'
 
+/**
+ * DTO describing a `Trimmer` transformer.
+ */
 export interface TrimmerDTO {
   transformerId: 'trim'
 }
 
+/**
+ * Transformer that trims leading and trailing whitespace when encoding a string.
+ */
 export class Trimmer
   implements SerializableTransformer<string, string, string, Strings.Trim, TrimmerDTO>
 {
@@ -19,20 +25,32 @@ export class Trimmer
     this.transformerId = 'trim'
   }
 
+  /**
+   * Trim whitespace from both ends of the decoded string.
+   */
   encode(decoded: string): string {
     return decoded.trim()
   }
 
+  /**
+   * Return the encoded string unchanged (trimming is not reversible).
+   */
   decode(encoded: string): string {
     return encoded
   }
 
+  /**
+   * Serialize this transformer to its DTO.
+   */
   toJSON() {
     return {
       transformerId: this.transformerId
     }
   }
 
+  /**
+   * Chain this transformer with another, applied after it.
+   */
   pipe<TRANSFORMER extends Transformer<string>>(
     transformer: TRANSFORMER
   ): Piped<[this, TRANSFORMER]> {
@@ -42,4 +60,7 @@ export class Trimmer
 
 type Trim = () => Trimmer
 
+/**
+ * Create a `Trimmer` transformer that trims whitespace from strings.
+ */
 export const trim: Trim = () => new Trimmer()

--- a/src/transformers/types.ts
+++ b/src/transformers/types.ts
@@ -7,10 +7,16 @@ import type {
   TypedTransformer
 } from './transformer.js'
 
+/**
+ * Extract the type-level modifier applied by a `Transformer` to its value.
+ */
 export type TypeModifier<TRANSFORMER extends Transformer> = TRANSFORMER extends TypedTransformer
   ? TRANSFORMER['_typeModifier']
   : Constant<ReturnType<TRANSFORMER['encode']>>
 
+/**
+ * Extract the type-level modifiers applied by a tuple of `Transformer`s.
+ */
 export type TypeModifiers<
   TRANSFORMERS extends Transformer[],
   FNS extends Fn[] = []
@@ -22,10 +28,16 @@ export type TypeModifiers<
     : never
   : FNS
 
+/**
+ * Extract the DTO type produced by a `SerializableTransformer`.
+ */
 export type TransformerDTO<TRANSFORMER extends SerializableTransformer> = ReturnType<
   TRANSFORMER['toJSON']
 >
 
+/**
+ * Extract the DTO types produced by a tuple of `SerializableTransformer`s.
+ */
 export type TransformerDTOs<
   TRANSFORMERS extends SerializableTransformer[],
   DTOS extends ITransformerDTO[] = []

--- a/src/transformers/utils.ts
+++ b/src/transformers/utils.ts
@@ -2,6 +2,9 @@ import { isObject } from '~/utils/validation/isObject.js'
 
 import type { SerializableTransformer } from './transformer.js'
 
+/**
+ * Type guard checking whether a value is a `SerializableTransformer`.
+ */
 export const isSerializableTransformer = (
   transformer: unknown
 ): transformer is SerializableTransformer =>


### PR DESCRIPTION
## Summary

Phase **5/10** of the [Enforce JSDoc with ESLint](https://app.notion.com/p/3b20336842e880908c1fc7fb7a7d13ec) rollout (follows phase 1, `src/schema/`, merged in #1291).

One reviewable PR that documents **`src/transformers/`** and flips its `jsdoc/require-jsdoc` ESLint override from `off` to `error`.

## Changes

- **`.eslintrc.json`** — add a `src/transformers/**/*.ts` override enabling `jsdoc/require-jsdoc: error` with the same presence-only options used for `src/schema/` (`publicOnly.esm`, `enableFixer: false`, `exemptEmptyConstructors`, public methods + types/interfaces/enums via `contexts`). Placed before the test-file override so transformer test files stay exempt.
- **8 source files** — author 49 presence-only JSDoc blocks (≤3 sentences, describe *what* the item does) on every exported value / type / interface / enum + non-private class method:
  - `transformer.ts`, `types.ts`, `utils.ts`
  - `prefix.ts`, `suffix.ts`, `trim.ts`, `jsonStringify.ts`, `pipe.ts`

## Notes

- Barrel `index.ts` is untouched — re-exports are not declarations, so they are never flagged (docs live on the source declaration).
- Presence-only: block content/format is not validated, per the umbrella spec.

## Verification

- `eslint .` → clean (rule now `error` for `src/transformers/`)
- `prettier --check` → clean
- `vitest run src/transformers` → pass
- `tsc --noEmit` → clean
- full `npm test` → green (type + format + unit + lint + exports)

## Docs

None — the Docusaurus site documents library usage, not repo linting; no page corresponds to this tooling change (per umbrella spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)