### PR TITLE
feat(lint): enforce jsdoc/require-jsdoc for src/database

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -111,6 +111,32 @@
       }
     },
     {
+      "files": ["src/database/**/*.ts"],
+      "rules": {
+        "jsdoc/require-jsdoc": [
+          "error",
+          {
+            "publicOnly": { "esm": true },
+            "enableFixer": false,
+            "exemptEmptyConstructors": true,
+            "require": {
+              "FunctionDeclaration": true,
+              "FunctionExpression": true,
+              "ArrowFunctionExpression": true,
+              "ClassDeclaration": true,
+              "ClassExpression": true
+            },
+            "contexts": [
+              "MethodDefinition:not([accessibility=\"private\"]):not([key.type=\"PrivateIdentifier\"])",
+              "TSTypeAliasDeclaration",
+              "TSInterfaceDeclaration",
+              "TSEnumDeclaration"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["**/*.test.ts"],
       "rules": {
         "@typescript-eslint/no-unused-vars": "off",

--- a/src/database/actions/mcpToolkit/addAccessPatternTool.ts
+++ b/src/database/actions/mcpToolkit/addAccessPatternTool.ts
@@ -42,6 +42,9 @@ interface AddAccessPatternToolOptions {
   dbAccessPatternKey: string
 }
 
+/**
+ * Register an MCP tool that runs a given access pattern.
+ */
 export const addAccessPatternTool = (
   server: McpServer,
   accessPattern: IEntityAccessPattern | ITableAccessPattern,

--- a/src/database/actions/mcpToolkit/addEntityTools/addDeleteItemTool.ts
+++ b/src/database/actions/mcpToolkit/addEntityTools/addDeleteItemTool.ts
@@ -20,6 +20,9 @@ const defaultDeleteOptionsSchema = z
   .partial()
   .default({})
 
+/**
+ * Register an MCP tool that deletes an item of the given entity.
+ */
 export const addDeleteEntityItemTool = (
   server: McpServer,
   entity: Entity,

--- a/src/database/actions/mcpToolkit/addEntityTools/addEntityTools.ts
+++ b/src/database/actions/mcpToolkit/addEntityTools/addEntityTools.ts
@@ -7,6 +7,9 @@ import { addGetEntityItemTool } from './addGetItemTool.js'
 import { addPutEntityItemTool } from './addPutItemTool.js'
 import type { AddEntityToolsOptions } from './options.js'
 
+/**
+ * Register the get / put / delete MCP tools for a single entity.
+ */
 export const addEntityTools = (
   server: McpServer,
   entity: Entity,

--- a/src/database/actions/mcpToolkit/addEntityTools/addGetItemTool.ts
+++ b/src/database/actions/mcpToolkit/addEntityTools/addGetItemTool.ts
@@ -18,6 +18,9 @@ const defaultGetOptionsSchema = z
   .partial()
   .default({})
 
+/**
+ * Register an MCP tool that gets an item of the given entity.
+ */
 export const addGetEntityItemTool = (
   server: McpServer,
   entity: Entity,

--- a/src/database/actions/mcpToolkit/addEntityTools/addPutItemTool.ts
+++ b/src/database/actions/mcpToolkit/addEntityTools/addPutItemTool.ts
@@ -20,6 +20,9 @@ const defaultPutOptionsSchema = z
   .partial()
   .default({})
 
+/**
+ * Register an MCP tool that puts an item of the given entity.
+ */
 export const addPutEntityItemTool = (
   server: McpServer,
   entity: Entity,

--- a/src/database/actions/mcpToolkit/addEntityTools/options.ts
+++ b/src/database/actions/mcpToolkit/addEntityTools/options.ts
@@ -1,5 +1,8 @@
 import type { AddToolsOptions } from '../options.js'
 
+/**
+ * Options for entity MCP tools, adding the database table key to `AddToolsOptions`.
+ */
 export interface AddEntityToolsOptions extends AddToolsOptions {
   dbTableKey: string
 }

--- a/src/database/actions/mcpToolkit/mcpToolkit.ts
+++ b/src/database/actions/mcpToolkit/mcpToolkit.ts
@@ -7,7 +7,13 @@ import { addAccessPatternTool } from './addAccessPatternTool.js'
 import { addEntityTools } from './addEntityTools/index.js'
 import type { AddToolsOptions } from './options.js'
 
+/**
+ * Database action that registers MCP tools for a database's entities and access patterns.
+ */
 export class MCPToolkit<DATABASE extends Database> extends DatabaseAction<DATABASE> {
+  /**
+   * Register MCP tools for every entity and access pattern on the given server.
+   */
   addTools(mcpServer: McpServer, options: AddToolsOptions = {}): this {
     for (const [dbTableKey, dbTable] of Object.entries(this.database.tables)) {
       for (const entity of Object.values(dbTable.entities)) {

--- a/src/database/actions/mcpToolkit/options.ts
+++ b/src/database/actions/mcpToolkit/options.ts
@@ -1,3 +1,6 @@
+/**
+ * Options for registering MCP tools, e.g. restricting them to read-only.
+ */
 export interface AddToolsOptions {
   readonly?: boolean
 }

--- a/src/database/actions/synchronize/constants.ts
+++ b/src/database/actions/synchronize/constants.ts
@@ -1,2 +1,5 @@
 export const $awsAccount = Symbol('$awsAccount')
+/**
+ * Type of the `$awsAccount` symbol used to tag AWS account entries.
+ */
 export type $awsAccount = typeof $awsAccount

--- a/src/database/actions/synchronize/deleteEntity.ts
+++ b/src/database/actions/synchronize/deleteEntity.ts
@@ -1,5 +1,8 @@
 import type { AWSConfig, FetchOpts } from './types.js'
 
+/**
+ * Delete an entity's schema from the synchronization registry.
+ */
 export const deleteEntity = async (
   {
     awsAccountId,

--- a/src/database/actions/synchronize/getTableEntityNames.ts
+++ b/src/database/actions/synchronize/getTableEntityNames.ts
@@ -1,5 +1,8 @@
 import type { AWSConfig, FetchOpts } from './types.js'
 
+/**
+ * Fetch the names of the entities registered for a table.
+ */
 export const getTableEntityNames = async (
   { awsAccountId, awsRegion, tableName }: AWSConfig & { tableName: string },
   { apiUrl, fetch: _fetch = fetch, apiKey }: FetchOpts

--- a/src/database/actions/synchronize/putAccessRole.ts
+++ b/src/database/actions/synchronize/putAccessRole.ts
@@ -1,10 +1,16 @@
 import type { AWSConfig, FetchOpts } from './types.js'
 
+/**
+ * An access role, identified by its name with an optional description.
+ */
 export interface AccessRole {
   roleName: string
   description?: string
 }
 
+/**
+ * Create an access role for an AWS account if it does not already exist.
+ */
 export const putAccessRole = async (
   accessRole: Pick<AWSConfig, 'awsAccountId'> & AccessRole,
   { apiUrl, fetch: _fetch = fetch, apiKey }: FetchOpts
@@ -41,6 +47,9 @@ export const putAccessRole = async (
   }
 }
 
+/**
+ * Assign an existing access role to a table.
+ */
 export const assignAccessRole = async (
   {
     awsAccountId,

--- a/src/database/actions/synchronize/putAwsAccount.ts
+++ b/src/database/actions/synchronize/putAwsAccount.ts
@@ -7,6 +7,9 @@ interface AWSAccount extends Pick<AWSConfig, 'awsAccountId'> {
   description?: string
 }
 
+/**
+ * Create or update an AWS account entry in the synchronization registry.
+ */
 export const putAWSAccount = async (
   awsAccount: AWSAccount,
   { apiUrl, fetch: _fetch = fetch, apiKey }: FetchOpts

--- a/src/database/actions/synchronize/putEntity.ts
+++ b/src/database/actions/synchronize/putEntity.ts
@@ -8,6 +8,9 @@ interface Entity extends Omit<IEntityDTO, 'table'> {
   description?: string
 }
 
+/**
+ * Create or update an entity's schema in the synchronization registry.
+ */
 export const putEntity = async (
   { awsAccountId, awsRegion, tableName, ...entity }: AWSConfig & { tableName: string } & Entity,
   { apiUrl, fetch: _fetch = fetch, apiKey }: FetchOpts

--- a/src/database/actions/synchronize/putTable.ts
+++ b/src/database/actions/synchronize/putTable.ts
@@ -10,6 +10,9 @@ interface Table extends AWSConfig, ITableDTO {
   description?: string
 }
 
+/**
+ * Create or update a table's schema in the synchronization registry.
+ */
 export const putTable = async (
   table: Table,
   { apiUrl, fetch: _fetch = fetch, apiKey }: FetchOpts

--- a/src/database/actions/synchronize/synchronizer.ts
+++ b/src/database/actions/synchronize/synchronizer.ts
@@ -12,12 +12,18 @@ import { putEntity } from './putEntity.js'
 import { putTable } from './putTable.js'
 import type { AWSAccount, FetchOpts, SyncedEntityMetadata, SyncedTableMetadata } from './types.js'
 
+/**
+ * Database action that synchronizes table and entity schemas to a remote registry.
+ */
 export class Synchronizer<DATABASE extends Database> extends DatabaseAction<DATABASE> {
   static override actionName = 'synchronize' as const
 
   apiUrl: string;
   [$awsAccount]?: AWSAccount
 
+  /**
+   * Create a synchronizer for a database, optionally bound to an AWS account.
+   */
   constructor(database: DATABASE, awsAccount?: AWSAccount) {
     super(database)
 
@@ -25,10 +31,16 @@ export class Synchronizer<DATABASE extends Database> extends DatabaseAction<DATA
     this[$awsAccount] = awsAccount
   }
 
+  /**
+   * Return a new synchronizer bound to the given AWS account.
+   */
   awsAccount(awsAccount: AWSAccount): Synchronizer<DATABASE> {
     return new Synchronizer(this.database, awsAccount)
   }
 
+  /**
+   * Push the database's table and entity schemas to the remote registry.
+   */
   async sync({
     apiKey,
     deleteUnknownEntities = false,

--- a/src/database/actions/synchronize/types.ts
+++ b/src/database/actions/synchronize/types.ts
@@ -3,17 +3,26 @@ import type { TableMetadata } from '~/table/index.js'
 
 import type { AccessRole } from './putAccessRole.js'
 
+/**
+ * AWS account and region identifying where a table lives.
+ */
 export interface AWSConfig {
   awsAccountId: string
   awsRegion: string
 }
 
+/**
+ * AWS account details displayed in the synchronization registry.
+ */
 export interface AWSAccount extends AWSConfig {
   color?: string
   title?: string
   description?: string
 }
 
+/**
+ * Table metadata extended with synchronization-specific fields.
+ */
 export interface SyncedTableMetadata extends TableMetadata {
   _ddbToolshack?: {
     icon?: string
@@ -21,12 +30,18 @@ export interface SyncedTableMetadata extends TableMetadata {
   }
 }
 
+/**
+ * Entity metadata extended with synchronization-specific fields.
+ */
 export interface SyncedEntityMetadata extends EntityMetadata {
   _ddbToolshack?: {
     icon?: string
   }
 }
 
+/**
+ * Options for the HTTP calls made during synchronization.
+ */
 export interface FetchOpts {
   apiUrl: string
   fetch: typeof fetch

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -3,17 +3,26 @@ import { Table } from '~/table/index.js'
 
 import type { DatabaseMetadata } from './types.js'
 
+/**
+ * A group of tables, used to run actions across a whole database.
+ */
 export class Database<
   TABLES extends Record<string, Table | Registry> = Record<string, Table | Registry>
 > {
   readonly tables: Register<TABLES>
   public meta: DatabaseMetadata
 
+  /**
+   * Create a database from a record of tables (or registries) and optional metadata.
+   */
   constructor(tables: TABLES, { meta = {} }: { meta?: DatabaseMetadata } = {}) {
     this.tables = register(tables)
     this.meta = meta
   }
 
+  /**
+   * Build an action from this database.
+   */
   build<ACTION extends DatabaseAction<this> = DatabaseAction<this>>(
     Action: new (table: this) => ACTION
   ): ACTION {
@@ -21,9 +30,15 @@ export class Database<
   }
 }
 
+/**
+ * Base class for actions run on a `Database`.
+ */
 export class DatabaseAction<DATABASE extends Database = Database> {
   static actionName: string
 
+  /**
+   * Bind this action to a database.
+   */
   constructor(readonly database: DATABASE) {}
 }
 

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Optional metadata attached to a `Database`, such as a title and description.
+ */
 export interface DatabaseMetadata {
   title?: string
   description?: string


### PR DESCRIPTION
## Summary

Phase **4/10** of the [Enforce JSDoc with ESLint](https://app.notion.com/p/3b20336842e880908c1fc7fb7a7d13ec) rollout (depends on phase 1, `src/schema/`, merged in #1291).

One reviewable PR that documents **`src/database/`** and flips its `jsdoc/require-jsdoc` ESLint override from `off` to `error`.

## Changes

- **`.eslintrc.json`** — add a `src/database/**/*.ts` override enabling `jsdoc/require-jsdoc: error` with the same presence-only options used for `src/schema/`. Placed before the test-file override so database test files stay exempt.
- **19 source files** — author 33 presence-only JSDoc blocks (≤3 sentences, describe *what* the item does) on every exported value / type / interface / enum + non-private class method:
  - core: `database.ts` (`Database`, `DatabaseAction`), `types.ts`
  - `mcpToolkit/`: `MCPToolkit` + `addTools`, the `add*Tool` factories, options interfaces
  - `synchronize/`: `Synchronizer` (ctor / `awsAccount` / `sync`), the put/delete/get helpers, `AccessRole`, `types.ts`, `$awsAccount`

## Notes

- Barrel `index.ts` files and non-exported internal interfaces are not flagged (re-exports / internals).
- Presence-only: block content/format is not validated, per the umbrella spec.

## Verification

- `eslint .` (full) → clean
- `prettier --check` → clean
- `tsc --noEmit` → clean
- no unit-test files under `src/database` (comments-only change, no runtime impact)

## Docs

None — the Docusaurus site documents library usage, not repo linting; no page corresponds to this tooling change (per umbrella spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)