### PR TITLE
feat(lint): enforce jsdoc/require-jsdoc for src/options

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -137,6 +137,32 @@
       }
     },
     {
+      "files": ["src/options/**/*.ts"],
+      "rules": {
+        "jsdoc/require-jsdoc": [
+          "error",
+          {
+            "publicOnly": { "esm": true },
+            "enableFixer": false,
+            "exemptEmptyConstructors": true,
+            "require": {
+              "FunctionDeclaration": true,
+              "FunctionExpression": true,
+              "ArrowFunctionExpression": true,
+              "ClassDeclaration": true,
+              "ClassExpression": true
+            },
+            "contexts": [
+              "MethodDefinition:not([accessibility=\"private\"]):not([key.type=\"PrivateIdentifier\"])",
+              "TSTypeAliasDeclaration",
+              "TSInterfaceDeclaration",
+              "TSEnumDeclaration"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["**/*.test.ts"],
       "rules": {
         "@typescript-eslint/no-unused-vars": "off",

--- a/src/options/capacity.ts
+++ b/src/options/capacity.ts
@@ -1,9 +1,21 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 
+/**
+ * `capacity` option requesting no consumed-capacity metrics.
+ */
 export type NoneCapacityOption = 'NONE'
+/**
+ * `capacity` option requesting total consumed-capacity metrics.
+ */
 export type TotalCapacityOption = 'TOTAL'
+/**
+ * `capacity` option requesting per-index consumed-capacity metrics.
+ */
 export type IndexesCapacityOption = 'INDEXES'
 
+/**
+ * Accepted values for the `capacity` command option.
+ */
 export type CapacityOption = NoneCapacityOption | TotalCapacityOption | IndexesCapacityOption
 
 export const capacityOptions = [
@@ -13,6 +25,9 @@ export const capacityOptions = [
 ] as const satisfies readonly CapacityOption[]
 export const capacityOptionsSet = new Set<CapacityOption>(capacityOptions)
 
+/**
+ * Validate a `capacity` option value, throwing on an unknown value.
+ */
 export const parseCapacityOption = (capacity: CapacityOption): CapacityOption => {
   if (!capacityOptionsSet.has(capacity)) {
     throw new DynamoDBToolboxError('options.invalidCapacityOption', {

--- a/src/options/clientRequestToken.ts
+++ b/src/options/clientRequestToken.ts
@@ -1,8 +1,14 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 import { isString } from '~/utils/validation/isString.js'
 
+/**
+ * Value type of the `clientRequestToken` command option.
+ */
 export type ClientRequestToken = string
 
+/**
+ * Validate a `clientRequestToken` option value, throwing if it is not a string.
+ */
 export const parseClientRequestToken = (clientRequestToken: unknown): ClientRequestToken => {
   if (!isString(clientRequestToken)) {
     throw new DynamoDBToolboxError('options.invalidClientRequestToken', {

--- a/src/options/consistent.ts
+++ b/src/options/consistent.ts
@@ -2,6 +2,9 @@ import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 import type { Index } from '~/table/index.js'
 import { isBoolean } from '~/utils/validation/isBoolean.js'
 
+/**
+ * Validate a `consistent` option value, rejecting consistent reads on global secondary indexes.
+ */
 export const parseConsistentOption = (consistent: boolean, index?: Index): boolean => {
   if (!isBoolean(consistent)) {
     throw new DynamoDBToolboxError('options.invalidConsistentOption', {

--- a/src/options/entityAttrFilter.ts
+++ b/src/options/entityAttrFilter.ts
@@ -3,6 +3,9 @@ import type { Entity } from '~/entity/index.js'
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 import { isBoolean } from '~/utils/validation/isBoolean.js'
 
+/**
+ * Validate an `entityAttrFilter` option value against the queried entities and filters.
+ */
 export const parseEntityAttrFilterOption = (
   entityAttrFilter: boolean,
   entities: Entity[],

--- a/src/options/errors.ts
+++ b/src/options/errors.ts
@@ -108,6 +108,9 @@ type MissingDocumentClientErrorBlueprint = ErrorBlueprint<{
   payload: undefined
 }>
 
+/**
+ * Union of error blueprints raised while parsing command options.
+ */
 export type OptionsErrorBlueprints =
   | IncompleteActionErrorBlueprint
   | InvalidActionErrorBlueprint

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -2,6 +2,9 @@ import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 import type { Table } from '~/table/index.js'
 import { isString } from '~/utils/validation/isString.js'
 
+/**
+ * Validate an `index` option value against the table's defined indexes.
+ */
 export const parseIndexOption = (table: Table, index: string): string => {
   if (!isString(index)) {
     throw new DynamoDBToolboxError('options.invalidIndexOption', {

--- a/src/options/limit.ts
+++ b/src/options/limit.ts
@@ -1,6 +1,9 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 import { isInteger } from '~/utils/validation/isInteger.js'
 
+/**
+ * Validate a `limit` option value, requiring an integer greater than 0.
+ */
 export const parseLimitOption = (limit: number): number => {
   if (!isInteger(limit) || limit <= 0) {
     throw new DynamoDBToolboxError('options.invalidLimitOption', {

--- a/src/options/maxPages.ts
+++ b/src/options/maxPages.ts
@@ -1,6 +1,9 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 import { isInteger } from '~/utils/validation/isInteger.js'
 
+/**
+ * Validate a `maxPages` option value, allowing `Infinity` or an integer greater than 0.
+ */
 export const parseMaxPagesOption = (maxPages: number): number => {
   if (maxPages === Infinity) {
     return maxPages

--- a/src/options/metrics.ts
+++ b/src/options/metrics.ts
@@ -1,12 +1,24 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 
+/**
+ * `metrics` option requesting no item-collection metrics.
+ */
 export type NoneMetricsOption = 'NONE'
+/**
+ * `metrics` option requesting item-collection size metrics.
+ */
 export type SizeMetricsOption = 'SIZE'
+/**
+ * Accepted values for the `metrics` command option.
+ */
 export type MetricsOption = NoneMetricsOption | SizeMetricsOption
 
 export const metricsOptions = ['NONE', 'SIZE'] as const satisfies readonly MetricsOption[]
 export const metricsOptionsSet = new Set<MetricsOption>(metricsOptions)
 
+/**
+ * Validate a `metrics` option value, throwing on an unknown value.
+ */
 export const parseMetricsOption = (metrics: MetricsOption): MetricsOption => {
   if (!metricsOptionsSet.has(metrics)) {
     throw new DynamoDBToolboxError('options.invalidMetricsOption', {

--- a/src/options/noEntityMatchBehavior.ts
+++ b/src/options/noEntityMatchBehavior.ts
@@ -1,12 +1,24 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 
+/**
+ * `noEntityMatchBehavior` option that discards items matching no entity.
+ */
 export type DiscardNoEntityMatchBehavior = 'DISCARD'
+/**
+ * `noEntityMatchBehavior` option that throws on items matching no entity.
+ */
 export type ThrowNoEntityMatchBehavior = 'THROW'
 
+/**
+ * Accepted values for the `noEntityMatchBehavior` command option.
+ */
 export type NoEntityMatchBehavior = DiscardNoEntityMatchBehavior | ThrowNoEntityMatchBehavior
 
 export const noEntityMatchBehaviorSet = new Set<NoEntityMatchBehavior>(['DISCARD', 'THROW'])
 
+/**
+ * Validate a `noEntityMatchBehavior` option value, throwing on an unknown value.
+ */
 export const parseNoEntityMatchBehavior = (
   noEntityMatchBehavior: NoEntityMatchBehavior
 ): NoEntityMatchBehavior => {

--- a/src/options/rejectExtraOptions.ts
+++ b/src/options/rejectExtraOptions.ts
@@ -1,5 +1,8 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 
+/**
+ * Throw if any unknown extra command option was provided.
+ */
 export const rejectExtraOptions = (extraOptions: {}): void => {
   const [extraOption] = Object.keys(extraOptions)
 

--- a/src/options/returnValues.ts
+++ b/src/options/returnValues.ts
@@ -1,11 +1,29 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 
+/**
+ * `returnValues` option requesting no returned attributes.
+ */
 export type NoneReturnValuesOption = 'NONE'
+/**
+ * `returnValues` option requesting all attributes as they were before the write.
+ */
 export type AllOldReturnValuesOption = 'ALL_OLD'
+/**
+ * `returnValues` option requesting the updated attributes as they were before the write.
+ */
 export type UpdatedOldReturnValuesOption = 'UPDATED_OLD'
+/**
+ * `returnValues` option requesting all attributes as they are after the write.
+ */
 export type AllNewReturnValuesOption = 'ALL_NEW'
+/**
+ * `returnValues` option requesting the updated attributes as they are after the write.
+ */
 export type UpdatedNewReturnValuesOption = 'UPDATED_NEW'
 
+/**
+ * Accepted values for the `returnValues` command option.
+ */
 export type ReturnValuesOption =
   | NoneReturnValuesOption
   | AllOldReturnValuesOption
@@ -13,6 +31,9 @@ export type ReturnValuesOption =
   | AllNewReturnValuesOption
   | UpdatedNewReturnValuesOption
 
+/**
+ * Validate a `returnValues` option value against the allowed set for a command.
+ */
 export const parseReturnValuesOption = <ALLOWED_RETURN_VALUES_OPTION extends ReturnValuesOption>(
   allowedReturnValuesOptions: Set<ALLOWED_RETURN_VALUES_OPTION>,
   returnValues: ALLOWED_RETURN_VALUES_OPTION

--- a/src/options/returnValuesOnConditionFalse.ts
+++ b/src/options/returnValuesOnConditionFalse.ts
@@ -2,6 +2,9 @@ import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 
 import type { AllOldReturnValuesOption, NoneReturnValuesOption } from './returnValues.js'
 
+/**
+ * Accepted values for the `returnValuesOnConditionFalse` command option.
+ */
 export type ReturnValuesOnConditionFalseOption = NoneReturnValuesOption | AllOldReturnValuesOption
 
 const returnValuesOnConditionFalseOptions = new Set<ReturnValuesOnConditionFalseOption>([
@@ -9,6 +12,9 @@ const returnValuesOnConditionFalseOptions = new Set<ReturnValuesOnConditionFalse
   'ALL_OLD'
 ])
 
+/**
+ * Validate a `returnValuesOnConditionFalse` option value, throwing on an unknown value.
+ */
 export const parseReturnValuesOnConditionFalseOption = (
   returnValues: ReturnValuesOnConditionFalseOption
 ): ReturnValuesOnConditionFalseOption => {

--- a/src/options/select.ts
+++ b/src/options/select.ts
@@ -1,10 +1,25 @@
 import { DynamoDBToolboxError } from '~/errors/index.js'
 
+/**
+ * `select` option requesting all item attributes.
+ */
 export type AllAttributesSelectOption = 'ALL_ATTRIBUTES'
+/**
+ * `select` option requesting all attributes projected into the queried index.
+ */
 export type AllProjectedAttributesSelectOption = 'ALL_PROJECTED_ATTRIBUTES'
+/**
+ * `select` option requesting only the matching item count.
+ */
 export type CountSelectOption = 'COUNT'
+/**
+ * `select` option requesting a specific set of attributes.
+ */
 export type SpecificAttributesSelectOption = 'SPECIFIC_ATTRIBUTES'
 
+/**
+ * Accepted values for the `select` command option.
+ */
 export type SelectOption =
   | AllAttributesSelectOption
   | AllProjectedAttributesSelectOption
@@ -19,6 +34,9 @@ export const selectOptions = [
 ] as const satisfies readonly SelectOption[]
 export const selectOptionsSet = new Set<SelectOption>(selectOptions)
 
+/**
+ * Validate a `select` option value against the queried index and requested attributes.
+ */
 export const parseSelectOption = (
   select: SelectOption,
   { index, attributes }: { index?: string; attributes?: string[] | undefined } = {}

--- a/src/options/showEntityAttr.ts
+++ b/src/options/showEntityAttr.ts
@@ -1,6 +1,9 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 import { isBoolean } from '~/utils/validation/isBoolean.js'
 
+/**
+ * Validate a `showEntityAttr` option value, requiring a boolean.
+ */
 export const parseShowEntityAttrOption = (showEntityAttr: boolean): boolean => {
   if (!isBoolean(showEntityAttr)) {
     throw new DynamoDBToolboxError('options.invalidShowEntityAttrOption', {

--- a/src/options/tableName.ts
+++ b/src/options/tableName.ts
@@ -1,6 +1,9 @@
 import { DynamoDBToolboxError } from '~/errors/dynamoDBToolboxError.js'
 import { isString } from '~/utils/validation/isString.js'
 
+/**
+ * Validate a `tableName` option value, requiring a string.
+ */
 export const parseTableNameOption = (tableName: string): string => {
   if (!isString(tableName)) {
     throw new DynamoDBToolboxError('options.invalidTableNameOption', {


### PR DESCRIPTION
## Summary

Phase **6/10** of the [Enforce JSDoc with ESLint](https://app.notion.com/p/3b20336842e880908c1fc7fb7a7d13ec) rollout (depends on phase 1, `src/schema/`, merged in #1291).

One reviewable PR that documents **`src/options/`** and flips its `jsdoc/require-jsdoc` ESLint override from `off` to `error`.

## Changes

- **`.eslintrc.json`** — add a `src/options/**/*.ts` override enabling `jsdoc/require-jsdoc: error` with the same presence-only options used for `src/schema/`. Placed before the test-file override so options test files stay exempt.
- **16 source files** — author 39 presence-only JSDoc blocks (≤3 sentences, describe *what* the item does) on every exported value / type / interface / enum + non-private class method:
  - option value-type unions and their members: `capacity`, `metrics`, `returnValues`, `select`, `noEntityMatchBehavior`, `returnValuesOnConditionFalse`, `clientRequestToken`
  - the `parse*Option` validators, `rejectExtraOptions`, `parseIndexOption`
  - the `OptionsErrorBlueprints` union

## Notes

- `index.ts` is not a pure barrel here — it declares `parseIndexOption`, which is documented.
- `const` arrays/sets (`capacityOptions`, `selectOptionsSet`, …) and non-exported internal blueprint types are not flagged.
- Presence-only: block content/format is not validated, per the umbrella spec.

## Verification

- `eslint .` (full) → clean
- `prettier --check` → clean
- `tsc --noEmit` → clean
- no unit-test files under `src/options` (comments-only change, no runtime impact)

## Docs

None — the Docusaurus site documents library usage, not repo linting; no page corresponds to this tooling change (per umbrella spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)